### PR TITLE
story card component 구현

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "jsxSingleQuote": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,8 +5426,7 @@
     "@mui/types": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.3.tgz",
-      "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==",
-      "requires": {}
+      "integrity": "sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw=="
     },
     "@mui/utils": {
       "version": "5.11.2",

--- a/src/components/StoriesPage/StoryCard.tsx
+++ b/src/components/StoriesPage/StoryCard.tsx
@@ -1,0 +1,54 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Card, CardContent, CardMedia, Typography } from '@mui/material';
+import useLazyLoadImage from '../../hooks/useLazyLoadImage';
+
+interface Props {
+  title: string;
+  id: string;
+  lazy?: boolean;
+}
+
+const StoryCard = ({ title, id, lazy = false }: Props) => {
+  const { loaded, imageRef } = useLazyLoadImage(lazy);
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    // todo: StoryCard 클릭 시 해당 story detail 페이지로 이동.
+    // navigate(`/story/${id}`);
+  };
+
+  return (
+    <Card
+      sx={{ maxWidth: 210, marginRight: '16px', cursor: 'pointer' }}
+      onClick={handleClick}
+    >
+      <CardMedia
+        component="img"
+        ref={imageRef}
+        sx={{ height: 280 }}
+        image={
+          loaded
+            ? 'https://picsum.photos/200'
+            : 'https://via.placeholder.com/200'
+        }
+        title="StoryCard component sample"
+      />
+      <CardContent>
+        <Typography
+          sx={{
+            textAlign: 'center',
+            width: '100%',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {title}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default StoryCard;

--- a/src/components/StoryPage/StoryItem/StoryCard.tsx
+++ b/src/components/StoryPage/StoryItem/StoryCard.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { Card, CardContent, CardMedia, Typography } from '@mui/material';
-import useLazyLoadImage from '../../hooks/useLazyLoadImage';
+import useLazyLoadImage from '../../../hooks/useLazyLoadImage';
 
 interface Props {
   title: string;

--- a/src/hooks/useLazyLoadImage.ts
+++ b/src/hooks/useLazyLoadImage.ts
@@ -1,0 +1,52 @@
+import { useState, useRef, useEffect } from 'react';
+
+const LOAD_IMAGE_EVENT_TYPE = 'loadImage';
+
+const useLazyLoadImage = (lazy = false) => {
+  const [loaded, setLoaded] = useState(false);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (!lazy) {
+      setLoaded(true);
+      return;
+    }
+
+    const handleLoadImage = () => {
+      setLoaded(true);
+    };
+
+    imageRef.current?.addEventListener(LOAD_IMAGE_EVENT_TYPE, handleLoadImage);
+
+    return () => {
+      imageRef.current?.removeEventListener(
+        LOAD_IMAGE_EVENT_TYPE,
+        handleLoadImage
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!lazy) return;
+
+    const observer = new IntersectionObserver(
+      (entries, intersectionObserver) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            intersectionObserver.unobserve(entry.target);
+            entry.target.dispatchEvent(new CustomEvent(LOAD_IMAGE_EVENT_TYPE));
+          }
+        });
+      },
+      {
+        threshold: 0.5,
+      }
+    );
+
+    imageRef.current && observer.observe(imageRef.current);
+  }, []);
+
+  return { loaded, imageRef };
+};
+
+export default useLazyLoadImage;


### PR DESCRIPTION
#18 

## 작업 목록
![image](https://user-images.githubusercontent.com/93233930/211320086-41e5c469-1c55-45d7-b84d-8614ed5906a5.png)
- StoryCard 컴포넌트 구현
  - Image가 한 화면에 많아질 수 있을거라 생각해 lazy load를 통해 네트워크 요청을 줄이고자 함.(useLazyLoadImage)
- prettier에 jsxSingleQuote의 default 값은 false여서 true로 설정.

## 궁금한 점
- StoryCard 크기는 모바일까지 고려해서 지금 크기가 적당할까요?
- StoryPage라는 폴더에 StoryCard를 넣었는데 이름이 적당할까요? 유리님과 상의해야 될 것 같네요!
