### PR TITLE
회원가입 기능구현

### DIFF
--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -5,15 +5,6 @@ import SignUpButton from './SignUpButton';
 import SignUpInput from './SignUpInput';
 import SignUpSelector from './SignUpSelector';
 
-interface SignUpOption {
-  fullName: string;
-  email: string;
-  password: string;
-  passwordConfirm: string;
-  birth: string;
-  career: string;
-}
-
 const SignUpForm = () => {
   const {
     values,
@@ -26,9 +17,7 @@ const SignUpForm = () => {
     careerError,
     handleSubmit,
     handleChange,
-  } = useForm<SignUpOption>({
-    // onSubmit: async (values: SignUpOption) => {},
-  });
+  } = useForm();
 
   return (
     <Container>

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -62,11 +62,29 @@ const useForm = () => {
     else setCareerError('');
     if (Object.values(values).filter((item) => item === '').length === 0) {
       try {
-        await axios.post(`${import.meta.env.VITE_API_URL}/signup`, {
-          email: values.email,
-          fullName: values.fullName,
-          password: values.password,
-        });
+        await axios
+          .post(`${import.meta.env.VITE_API_URL}/signup`, {
+            email: values.email,
+            fullName: values.fullName,
+            password: values.password,
+          })
+          .then(({ data }) =>
+            axios({
+              url: `${import.meta.env.VITE_API_URL}/settings/update-user`,
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${data.token}`,
+              },
+              data: {
+                fullName: values.fullName,
+                username: JSON.stringify({
+                  birth: values.birth,
+                  career: values.career,
+                }),
+              },
+            })
+          );
         // login()
         // redirect('/')
       } catch (error) {

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,10 +1,7 @@
+import axios from 'axios';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
-interface Props<T> {
-  onSubmit?: (args: T) => void;
-}
-
-const useForm = <T>({ onSubmit }: Props<T>) => {
+const useForm = () => {
   const [values, setValues] = useState({
     fullName: '',
     email: '',
@@ -28,9 +25,10 @@ const useForm = <T>({ onSubmit }: Props<T>) => {
     setValues({ ...values, [name]: value.replace(/\s/g, '') });
   };
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    setIsLoading(true);
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    setIsLoading(true);
+
     const emailRegex =
       /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
     const passwordRegex =
@@ -62,8 +60,21 @@ const useForm = <T>({ onSubmit }: Props<T>) => {
 
     if (!values.career) setCareerError('직업을 입력해주세요.');
     else setCareerError('');
-
-    setIsLoading(false);
+    if (Object.values(values).filter((item) => item === '').length === 0) {
+      try {
+        await axios.post(`${import.meta.env.VITE_API_URL}/signup`, {
+          email: values.email,
+          fullName: values.fullName,
+          password: values.password,
+        });
+        // login()
+        // redirect('/')
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
   };
 
   return {


### PR DESCRIPTION
issues #35

## 작업 목록
- 기본정보 (fullName, email, password)를 통한 회원가입
- 추가정보
  회원가입이 성공적으로 완료되었다면 사용자 정보 변경 api를 호출하여
  (birth, career)정보 기입
  (username: birth, career)

### 참고 사진이 있다면 첨부

## 예정
- api 호출 로직 분리
- 회원가입 완료시 login 기능 및 홈으로 이동
## 궁금한 점
현재 회원가입시
1. 기본정보를 통한 회원가입
2. 추가정보를 통한 사용자 정보 변경
3. 로그인
이렇게 3번의 api호출이 발생할 것 같습니다. 더 좋은방법 있으면 남겨주세요!