### PR TITLE
SearchForm 공백 에러 처리 및 home header 로고 수정

### DIFF
--- a/src/components/Home/SearchForm.tsx
+++ b/src/components/Home/SearchForm.tsx
@@ -8,8 +8,13 @@ interface Props {
 }
 
 const SearchForm = ({ onSubmit }: Props) => {
-  const { value, handleInputChange, handleInputClear, handleFormSubmit } =
-    useSearhForm({ onSubmit });
+  const {
+    value,
+    error,
+    handleInputChange,
+    handleInputClear,
+    handleFormSubmit,
+  } = useSearhForm({ onSubmit });
 
   return (
     <Box>
@@ -20,8 +25,7 @@ const SearchForm = ({ onSubmit }: Props) => {
           position: 'relative',
           marginBottom: '10px',
         }}
-        onSubmit={handleFormSubmit}
-      >
+        onSubmit={handleFormSubmit}>
         <TextField
           sx={{
             width: '100%',
@@ -33,11 +37,12 @@ const SearchForm = ({ onSubmit }: Props) => {
             //TODO: input focus boder-bottom #f99b0f
           }}
           variant='standard'
-          required
           autoFocus
           type='text'
           label='user name'
           value={value}
+          error={error.keyword !== ''}
+          helperText={error.keyword}
           onChange={handleInputChange}
         />
         <IconButton
@@ -49,8 +54,7 @@ const SearchForm = ({ onSubmit }: Props) => {
             top: '30px',
             color: '#167fe7',
           }}
-          onClick={handleInputClear}
-        >
+          onClick={handleInputClear}>
           <HighlightOff />
         </IconButton>
       </Box>

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import FontText from '../Home/FontText';
+
 const Header = () => {
   const [click, setClick] = useState(false);
   const handleClick = () => setClick(!click);
@@ -9,7 +11,17 @@ const Header = () => {
 
   return (
     <Container>
-      <Logo onClick={() => navigate('/')}>빅토리아</Logo>
+      <Logo onClick={() => navigate('/')}>
+        <FontText
+          component='h4'
+          title='B.'
+          sx={{
+            display: 'inline-block',
+            marginBottom: '30px',
+            fontSize: '30px',
+          }}
+        />
+      </Logo>
       <HamburgerButton onClick={handleClick}>
         {click ? (
           <img src='/public/icons/close.svg' />

--- a/src/hooks/useSearchForm.ts
+++ b/src/hooks/useSearchForm.ts
@@ -6,9 +6,28 @@ interface Props {
 
 const useSearhForm = ({ onSubmit }: Props) => {
   const [value, setValue] = useState('');
+  const [error, setError] = useState({
+    keyword: '',
+  });
+
+  const ERROR_MESSAGE_NO_BLANK = '공백 문자는 허용되지 않습니다.';
+  const ERROR_MESSAGE_REQUIRED_KEYWORD = '검색어를 입력해주세요';
+  const validateSearchInput = (keyword: string) => {
+    const error = { keyword: '' };
+
+    if (keyword.match(/[\s]/g)) error.keyword = ERROR_MESSAGE_NO_BLANK;
+    if (keyword.length === 0) error.keyword = ERROR_MESSAGE_REQUIRED_KEYWORD;
+
+    return error;
+  };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+    const keyword = e.target.value;
+
+    const newError = validateSearchInput(keyword);
+    setError(newError);
+
+    setValue(keyword.replace(/[\s]/g, ''));
   };
 
   const handleInputClear = () => {
@@ -20,14 +39,19 @@ const useSearhForm = ({ onSubmit }: Props) => {
 
     const keyword = value;
 
-    if (keyword.replace(/[\s]/g, '').length) {
-      onSubmit(value.trim());
-    }
+    const newError = validateSearchInput(keyword);
+    setError(newError);
 
-    setValue(value.trim());
+    !newError.keyword.length && onSubmit(keyword);
   };
 
-  return { value, handleInputChange, handleInputClear, handleFormSubmit };
+  return {
+    value,
+    error,
+    handleInputChange,
+    handleInputClear,
+    handleFormSubmit,
+  };
 };
 
 export default useSearhForm;

--- a/src/hooks/useSearchForm.ts
+++ b/src/hooks/useSearchForm.ts
@@ -1,5 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 
+import { validateSearchInput } from '../utils/validationSearchForm';
+
 interface Props {
   onSubmit: (keyword: string) => void;
 }
@@ -9,17 +11,6 @@ const useSearhForm = ({ onSubmit }: Props) => {
   const [error, setError] = useState({
     keyword: '',
   });
-
-  const ERROR_MESSAGE_NO_BLANK = '공백 문자는 허용되지 않습니다.';
-  const ERROR_MESSAGE_REQUIRED_KEYWORD = '검색어를 입력해주세요';
-  const validateSearchInput = (keyword: string) => {
-    const error = { keyword: '' };
-
-    if (keyword.match(/[\s]/g)) error.keyword = ERROR_MESSAGE_NO_BLANK;
-    if (keyword.length === 0) error.keyword = ERROR_MESSAGE_REQUIRED_KEYWORD;
-
-    return error;
-  };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const keyword = e.target.value;

--- a/src/utils/validationSearchForm.ts
+++ b/src/utils/validationSearchForm.ts
@@ -1,0 +1,11 @@
+const ERROR_MESSAGE_NO_BLANK = '공백 문자는 허용되지 않습니다.';
+const ERROR_MESSAGE_REQUIRED_KEYWORD = '검색어를 입력해주세요';
+
+export const validateSearchInput = (keyword: string) => {
+  const error = { keyword: '' };
+
+  if (keyword.match(/[\s]/g)) error.keyword = ERROR_MESSAGE_NO_BLANK;
+  if (keyword.length === 0) error.keyword = ERROR_MESSAGE_REQUIRED_KEYWORD;
+
+  return error;
+};


### PR DESCRIPTION
<!-- PR 제목과 동일 - 리팩터링 2판 챕터 숫자 + 제목 -->

# 이슈 번호가 있다면 적어주세요
[#77 ]

## 작업 목록

- [x] 검색어 예외처리
      - 공백 입력 시 helperText
      - 검색어 없을 때의 예외처리
- [x] Home Header 수정 

### 참고 사진이
![화면 캡처 2023-01-13 182519](https://user-images.githubusercontent.com/59648372/212285047-adfe7497-a466-4169-9eb0-9c62cfb30c6c.png)
 
![화면 캡처 2023-01-13 182006](https://user-images.githubusercontent.com/59648372/212284824-1542cdba-97c3-4413-858b-6883e136e8de.png)

로고 만들 시간 부족하다면, 그냥 이렇게 처리하는 것은 어떤지....제안해봅니다!

## 예정

- 알림 API 계속 뜯어봅니다.
- 사용자 전체 목록 무한스크롤(기간을 넉넉히 잡을 예정)

## 궁금한 점

작업하는데 영향갈까봐, 따로 validationSearchForm이랑 에러메세지 상수를 안에 넣었는데, 합칠 계획이 있으신지 다른 분들 궁금하네용:)
