### PR TITLE
스토리 조회 페이지 레이아웃 수정, 작성 에러 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Header from './components/shared/Header';
+import ScrollTopTop from './components/shared/ScrollToTop';
 import { ROUTES } from './constants/routes';
 import NotFound from './pages/404';
 import Chat from './pages/Chat';
@@ -15,6 +16,7 @@ import StoryEdit from './pages/StoryEdit';
 const App = () => {
   return (
     <BrowserRouter>
+      <ScrollTopTop />
       <Header />
       <Routes>
         <Route path={ROUTES.HOME} element={<Home />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Header from './components/shared/Header';
-import ScrollTopTop from './components/shared/ScrollToTop';
+import ScrollToTop from './components/shared/ScrollToTop';
 import { ROUTES } from './constants/routes';
 import NotFound from './pages/404';
 import Chat from './pages/Chat';
@@ -16,7 +16,7 @@ import StoryEdit from './pages/StoryEdit';
 const App = () => {
   return (
     <BrowserRouter>
-      <ScrollTopTop />
+      <ScrollToTop />
       <Header />
       <Routes>
         <Route path={ROUTES.HOME} element={<Home />} />

--- a/src/apis/story.ts
+++ b/src/apis/story.ts
@@ -3,7 +3,15 @@ import http from './instance';
 
 export const getStoriesOfUser = async (userId: string) => {
   const { data: stories } = await http.get({
-    url: `${API_URLS.POST.GET_POSTS_OF_SPECIFIC_USER(userId)}`,
+    url: API_URLS.POST.GET_POSTS_OF_SPECIFIC_USER(userId),
+  });
+
+  return stories;
+};
+
+export const getStoriesOfChannel = async (channelId: string) => {
+  const { data: stories } = await http.get({
+    url: API_URLS.POST.GET_POSTS_OF_SPECIFIC_CHANNEL(channelId),
   });
 
   return stories;

--- a/src/components/Story/CommentForm.tsx
+++ b/src/components/Story/CommentForm.tsx
@@ -31,7 +31,6 @@ const CommentForm = ({
         }
         value={comment}
         onChange={handleChange}
-        required
         disabled={!hasToken}></TextField>
       <Button type='submit' disabled={!hasToken || isLoading}>
         댓글 작성

--- a/src/components/Story/CommentForm.tsx
+++ b/src/components/Story/CommentForm.tsx
@@ -24,6 +24,8 @@ const CommentForm = ({
     <Form onSubmit={handleSubmit}>
       <TextField
         fullWidth
+        multiline
+        rows={4}
         placeholder={
           hasToken ? '댓글을 입력해 주세요.' : '로그인 후 이용해 주세요'
         }
@@ -32,7 +34,7 @@ const CommentForm = ({
         required
         disabled={!hasToken}></TextField>
       <Button type='submit' disabled={!hasToken || isLoading}>
-        등록
+        댓글 작성
       </Button>
     </Form>
   );
@@ -42,4 +44,7 @@ export default CommentForm;
 
 const Form = styled.form`
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
 `;

--- a/src/components/Story/CommentList.tsx
+++ b/src/components/Story/CommentList.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const CommentList = ({ comments, handleDelete }: Props) => {
-  const { user } = useFetchUser();
+  const { user, isLoading } = useFetchUser();
   const navigate = useNavigate();
 
   return (
@@ -48,7 +48,7 @@ const CommentList = ({ comments, handleDelete }: Props) => {
             </NameWrapper>
             <ContentWrapper>{comment.comment}</ContentWrapper>
           </ListItemText>
-          {user._id === comment.author._id && (
+          {!isLoading && user && user._id === comment.author._id && (
             <Button variant='text' onClick={() => handleDelete(comment._id)}>
               삭제
             </Button>

--- a/src/components/Story/CommentList.tsx
+++ b/src/components/Story/CommentList.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {
   Avatar,
   Button,
@@ -23,14 +24,14 @@ const CommentList = ({ comments, handleDelete }: Props) => {
   const navigate = useNavigate();
 
   return (
-    <List>
+    <List sx={{ padding: '20px 0' }}>
       {comments.map((comment) => (
         <ListItem
           key={comment._id}
           secondaryAction={
             <IconButton edge='end' aria-label='delete'></IconButton>
           }
-          sx={{ paddingRight: 0 }}>
+          sx={{ padding: '15px 0', alignItems: 'flex-start' }}>
           <ListItemAvatar
             sx={{ cursor: 'pointer' }}
             onClick={() =>
@@ -38,14 +39,15 @@ const CommentList = ({ comments, handleDelete }: Props) => {
             }>
             <Avatar alt='profile image' src={comment.author?.image} />
           </ListItemAvatar>
-          <ListItemText
-            sx={{ cursor: 'pointer' }}
-            primary={comment.author.fullName}
-            secondary={comment.comment}
-            onClick={() =>
-              navigate(ROUTES.STORY_BOOK_BY_USER_ID(comment.author._id))
-            }
-          />
+          <ListItemText>
+            <NameWrapper
+              onClick={() =>
+                navigate(ROUTES.STORY_BOOK_BY_USER_ID(comment.author._id))
+              }>
+              {comment.author.fullName}
+            </NameWrapper>
+            <ContentWrapper>{comment.comment}</ContentWrapper>
+          </ListItemText>
           {user._id === comment.author._id && (
             <Button variant='text' onClick={() => handleDelete(comment._id)}>
               삭제
@@ -58,3 +60,12 @@ const CommentList = ({ comments, handleDelete }: Props) => {
 };
 
 export default CommentList;
+
+const NameWrapper = styled.span`
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const ContentWrapper = styled.div`
+  white-space: pre-wrap;
+`;

--- a/src/components/Story/StoryComment.tsx
+++ b/src/components/Story/StoryComment.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 
-import { useCommentForm, useDeleteComment } from '../../hooks/useComment';
+import { useCommentForm } from '../../hooks/useComment';
 import { Comment } from '../../interfaces/comment';
 import CommentForm from './CommentForm';
 import CommentList from './CommentList';
@@ -11,8 +11,8 @@ interface Props {
 }
 
 const StoryComment = ({ comments, fetchComment }: Props) => {
-  const { comment, isLoading, handleChange, handleSubmit } = useCommentForm();
-  const { handleDelete } = useDeleteComment();
+  const { comment, isLoading, handleChange, handleDelete, handleSubmit } =
+    useCommentForm();
 
   return (
     <Box>

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -39,7 +39,7 @@ const StoryInfo = ({ story }: Props) => {
         </Typography>
         <DateContainer>
           <Typography variant='subtitle1'>
-            {year}.{month}.{day}
+            {year}년 {month}월 {day}일
           </Typography>
           {user && user._id === story.author._id && (
             <Box>

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -1,5 +1,11 @@
 import styled from '@emotion/styled';
-import { Avatar, Button, Paper, Typography } from '@mui/material';
+import {
+  Avatar,
+  Button,
+  CircularProgress,
+  Paper,
+  Typography,
+} from '@mui/material';
 import { Box } from '@mui/system';
 import { useNavigate } from 'react-router-dom';
 
@@ -20,6 +26,8 @@ const StoryInfo = ({ story }: Props) => {
 
   const { storyTitle, year, month, day, content } = JSON.parse(story.title);
 
+  if (isLoading) return <CircularProgress />;
+
   return (
     <>
       <Box>
@@ -33,7 +41,7 @@ const StoryInfo = ({ story }: Props) => {
           <Typography variant='subtitle1'>
             {year}.{month}.{day}
           </Typography>
-          {user._id === story.author._id && (
+          {user && user._id === story.author._id && (
             <Box>
               <Button
                 variant='text'
@@ -71,7 +79,7 @@ const StoryInfo = ({ story }: Props) => {
             {content}
           </StoryContentWrapper>
         )}
-        {!isLoading && (
+        {!isLoading && user && (
           <LikeButton
             userId={user._id}
             storyId={story._id}
@@ -106,13 +114,12 @@ const StoryContainer = styled(Box)`
 `;
 
 const StoryImageWrapper = styled.div`
-  height: 300px;
+  display: flex;
   padding: 15px 0;
 `;
 
 const StoryImage = styled.img`
   width: 100%;
-  max-height: 300px;
   object-fit: contain;
   cursor: pointer;
 `;

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -23,12 +23,15 @@ const StoryInfo = ({ story }: Props) => {
   return (
     <>
       <Box>
-        <StoryHeader>
-          <Typography
-            variant='h3'
-            gutterBottom
-            sx={{ fontSize: '2rem', fontWeight: '500' }}>
-            {storyTitle}
+        <Typography
+          variant='h3'
+          gutterBottom
+          sx={{ fontSize: '2rem', fontWeight: '500' }}>
+          {storyTitle}
+        </Typography>
+        <DateContainer>
+          <Typography variant='subtitle1'>
+            {year}.{month}.{day}
           </Typography>
           {user._id === story.author._id && (
             <Box>
@@ -46,11 +49,8 @@ const StoryInfo = ({ story }: Props) => {
               </Button>
             </Box>
           )}
-        </StoryHeader>
-        <Typography variant='subtitle1' gutterBottom>
-          {year}.{month}.{day}
-        </Typography>
-        <Box>
+        </DateContainer>
+        <Box sx={{ padding: '3px 0' }}>
           <Profile
             onClick={() =>
               navigate(ROUTES.STORY_BOOK_BY_USER_ID(story.author._id))
@@ -67,11 +67,9 @@ const StoryInfo = ({ story }: Props) => {
           </StoryImageWrapper>
         )}
         {content && (
-          <Paper
-            variant='outlined'
-            sx={{ width: '90%', padding: '30px', margin: '20px 0' }}>
+          <StoryContentWrapper variant='outlined'>
             {content}
-          </Paper>
+          </StoryContentWrapper>
         )}
         {!isLoading && (
           <LikeButton
@@ -87,9 +85,10 @@ const StoryInfo = ({ story }: Props) => {
 
 export default StoryInfo;
 
-const StoryHeader = styled(Box)`
+const DateContainer = styled(Box)`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const Profile = styled.span`
@@ -115,4 +114,14 @@ const StoryImage = styled.img`
   width: 100%;
   max-height: 300px;
   object-fit: contain;
+  cursor: pointer;
+`;
+
+const StoryContentWrapper = styled(Paper)`
+  min-width: 90%;
+  padding: 25px;
+  margin: 15px 0;
+  line-height: 1.5rem;
+  word-break: keep-all;
+  white-space: pre-wrap;
 `;

--- a/src/components/StoryBook/StoriesByYear.tsx
+++ b/src/components/StoryBook/StoriesByYear.tsx
@@ -45,7 +45,7 @@ const CardsContainer = styled.div`
   width: 100%;
   display: flex;
   flex-wrap: nowrap;
-  align-items: center;
+  align-items: flex-end;
   overflow-x: auto;
   padding: 1rem;
 `;

--- a/src/components/StoryBook/StoriesByYear.tsx
+++ b/src/components/StoryBook/StoriesByYear.tsx
@@ -9,8 +9,7 @@ const StoriesByYear = ({ year, stories }: StoriesWithYear) => {
       <Year>{year}</Year>
       <CardsContainer>
         {stories.map((story) => {
-          const { storyTitle, month }: { storyTitle: string; month: string } =
-            JSON.parse(story.title);
+          const { storyTitle, month } = JSON.parse(story.title);
 
           return (
             <CardContainer key={story._id}>

--- a/src/components/StoryEdit/StoryEditForm.tsx
+++ b/src/components/StoryEdit/StoryEditForm.tsx
@@ -57,7 +57,7 @@ const StoryEditForm = ({ story }: Props) => {
             placeholder='스토리의 제목을 입력하세요.'
             onChange={handleChange}
           />
-          {errors.title}
+          <ErrorText>{errors.title}</ErrorText>
         </InputDiv>
       </Section>
       <Section>
@@ -82,7 +82,7 @@ const StoryEditForm = ({ story }: Props) => {
             placeholder='스토리의 내용을 입력하세요.'
             onChange={handleChange}
           />
-          {errors.content}
+          <ErrorText>{errors.content}</ErrorText>
         </InputDiv>
       </Section>
       <SubmitButton isLoading={isLoading} />
@@ -109,4 +109,8 @@ const ImagePreview = styled.img`
   max-width: 100%;
   height: 300px;
   object-fit: contain;
+`;
+
+const ErrorText = styled.small`
+  color: red;
 `;

--- a/src/components/shared/ScrollToTop.tsx
+++ b/src/components/shared/ScrollToTop.tsx
@@ -5,7 +5,7 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   }, [pathname]);
 
   return null;

--- a/src/components/shared/ScrollToTop.tsx
+++ b/src/components/shared/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollTopTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollTopTop;

--- a/src/components/shared/ScrollToTop.tsx
+++ b/src/components/shared/ScrollToTop.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const ScrollTopTop = () => {
+const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
@@ -11,4 +11,4 @@ const ScrollTopTop = () => {
   return null;
 };
 
-export default ScrollTopTop;
+export default ScrollToTop;

--- a/src/hooks/useComment.ts
+++ b/src/hooks/useComment.ts
@@ -1,17 +1,34 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { deleteStoryComment, postStoryComment } from '../apis/story';
 import { ERROR_MESSAGES } from '../constants/errorMessages';
+import { ROUTES } from '../constants/routes';
 import { isBlankString } from '../utils/validations';
 
 export const useCommentForm = () => {
   const [comment, setComment] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { storyId } = useParams();
+  const navigate = useNavigate();
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
+  };
+
+  const handleDelete = async (commentId: string) => {
+    if (confirm('댓글을 삭제하시겠습니까?')) {
+      try {
+        if (!commentId) {
+          navigate(ROUTES.NOT_FOUND);
+          return;
+        }
+        await deleteStoryComment(commentId);
+      } catch (error) {
+        console.error(error);
+        alert(ERROR_MESSAGES.INVOKED_ERROR_DELETING_COMMENT);
+      }
+    }
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -22,7 +39,10 @@ export const useCommentForm = () => {
       alert('댓글 내용을 입력해 주세요.');
     } else {
       try {
-        if (!storyId) throw Error('잘못된 스토리 접근(storyId)');
+        if (!storyId) {
+          navigate(ROUTES.NOT_FOUND);
+          return;
+        }
         await postStoryComment(comment, storyId);
       } catch (error) {
         console.error(error);
@@ -35,21 +55,5 @@ export const useCommentForm = () => {
     setIsLoading(false);
   };
 
-  return { comment, isLoading, handleChange, handleSubmit };
-};
-
-export const useDeleteComment = () => {
-  const handleDelete = async (commentId: string) => {
-    if (confirm('댓글을 삭제하시겠습니까?')) {
-      try {
-        if (!commentId) throw Error('잘못된 댓글 접근(commentId)');
-        await deleteStoryComment(commentId);
-      } catch (error) {
-        console.error(error);
-        alert(ERROR_MESSAGES.INVOKED_ERROR_DELETING_COMMENT);
-      }
-    }
-  };
-
-  return { handleDelete };
+  return { comment, isLoading, handleChange, handleDelete, handleSubmit };
 };

--- a/src/hooks/useFetchStories.ts
+++ b/src/hooks/useFetchStories.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ERROR_MESSAGES } from '../constants/errorMessages';
+import { ROUTES } from '../constants/routes';
 import {
   StoriesWithYear,
   Story,
@@ -83,8 +84,7 @@ const useFetchStories = () => {
           const fetchedStories = await getStoriesOfUser(userId);
           setStories(fetchedStories);
         } else {
-          // todo: 404 페이지로 리다이렉팅
-          // navigate(404 페이지)
+          navigate(ROUTES.NOT_FOUND);
         }
       } catch (error) {
         console.error(error);

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -2,12 +2,10 @@ import { useEffect, useState } from 'react';
 
 import { checkAuth } from '../apis/auth';
 import { ERROR_MESSAGES } from '../constants/errorMessages';
+import { User } from '../interfaces/user';
 
 const useFetchUser = () => {
-  const [user, setUser] = useState({
-    _id: '',
-    likes: [],
-  });
+  const [user, setUser] = useState<User>();
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {

--- a/src/hooks/useLike.ts
+++ b/src/hooks/useLike.ts
@@ -19,7 +19,7 @@ const useLike = (userId: string, storyLikes: Like[], storyId: string) => {
       setIsLike(true);
       setLikeId(findStoryLike._id);
     }
-  }, []);
+  }, [userId]);
 
   const handleClick = async () => {
     if (!userId) {

--- a/src/hooks/useStory.ts
+++ b/src/hooks/useStory.ts
@@ -4,9 +4,12 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { deleteStory, getStoryDetail, postStory } from '../apis/story';
 import { ROUTES } from '../constants/routes';
+import { Story } from '../interfaces/story';
 import { isBlankString } from '../utils/validations';
-import { putStory } from './../apis/story';
+import { getStoriesOfChannel, putStory } from './../apis/story';
 import { ERROR_MESSAGES } from './../constants/errorMessages';
+
+const channelId = '63b6822ade9d2a22cc1d45c3';
 
 export const useFetchStory = () => {
   const [story, setStory] = useState({
@@ -38,8 +41,14 @@ export const useFetchStory = () => {
         if (storyId === 'new') {
           setIsNew(true);
         } else {
-          const fetchedStories = await getStoryDetail(storyId);
-          setStory(fetchedStories);
+          const stories = await getStoriesOfChannel(channelId);
+          if (!stories.find((story: Story) => story._id === storyId)) {
+            alert('존재하지 않는 스토리입니다.');
+            navigate(ROUTES.HOME);
+          }
+
+          const storyDetail = await getStoryDetail(storyId);
+          setStory(storyDetail);
         }
       } catch (error) {
         console.error(error);
@@ -84,7 +93,6 @@ interface StoryInfo {
 }
 
 export const useStoryForm = (initialValues: StoryInfo | undefined) => {
-  const channelId = '63b6822ade9d2a22cc1d45c3';
   const today = dayjs(new Date());
 
   const [values, setValues] = useState(
@@ -225,7 +233,7 @@ export const useDeleteStory = () => {
       try {
         if (!storyId) throw Error();
         await deleteStory(storyId);
-        navigate(`/story-book/${authorId}`);
+        navigate(ROUTES.STORY_BOOK_BY_USER_ID(authorId));
       } catch (error) {
         console.error(error);
         alert(ERROR_MESSAGES.INVOKED_ERROR_DELETING_STORY);

--- a/src/hooks/useStory.ts
+++ b/src/hooks/useStory.ts
@@ -24,12 +24,16 @@ export const useFetchStory = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isNew, setIsNew] = useState(false);
   const { storyId } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchStory = async () => {
       setIsLoading(true);
       try {
-        if (!storyId) return Error('잘못된 스토리 접근(storyId)'); // TODO: 404 페이지로 리다이렉트
+        if (!storyId) {
+          navigate(ROUTES.NOT_FOUND);
+          return;
+        }
 
         if (storyId === 'new') {
           setIsNew(true);
@@ -46,7 +50,7 @@ export const useFetchStory = () => {
     };
 
     fetchStory();
-  }, []);
+  }, [storyId]);
 
   const fetchComment = async () => {
     try {
@@ -181,6 +185,7 @@ export const useStoryForm = (initialValues: StoryInfo | undefined) => {
     const newErrors = validate();
     if (newErrors.title || newErrors.content) {
       setErrors(newErrors);
+      setIsLoading(false);
       return;
     }
 

--- a/src/pages/StoryEdit.tsx
+++ b/src/pages/StoryEdit.tsx
@@ -16,17 +16,17 @@ const StoryEdit = () => {
   useEffect(() => {
     if (isNew || isUserLoading || isStoryLoading) return;
 
-    if (user._id && user._id !== story.author._id) {
+    if (user?._id && user._id !== story.author._id) {
       alert('올바르지 않은 접근입니다.');
       navigate(ROUTES.HOME);
     }
-  }, []);
+  }, [user, story]);
 
   if (isUserLoading || isStoryLoading) return <CircularProgress />;
 
   return (
     <Container>
-      <h1>스토리 {!isNew || story._id ? '수정' : '추가'}</h1>
+      <h1>{!isNew || story._id ? '스토리 수정' : '스토리 추가'}</h1>
       <StoryEditForm story={story} />
     </Container>
   );


### PR DESCRIPTION
## 작업 목록
- 스토리 수정/삭제 버튼 위치 변경
- 스토리 내용 행간 조정 및 줄 바꿈 처리
- 댓글 장문 대응 및 버튼 위치 변경
- 페이지 이동 시 스크롤 초기화(ScrollToTop 컴포넌트를 App.tsx에 추가함)
- useEffect 로직 보완
- 삭제된 스토리 페이지에 접근 시 홈 페이지로 이동 처리
- 스토리북 월 flex 정렬 스타일 수정

### 참고 사진이 있다면 첨부
<img width="50%" src="https://user-images.githubusercontent.com/63575891/212548932-9d715f55-e208-4eb1-8690-35f79072a4a2.png" />

## 예정
- 모바일에서 DatePicker 조작 시 body 레이아웃 밀림 현상 해결 

## 궁금한 점
