### PR TITLE
스토리 사진 업로드 방식 추가, 스토리 페이지 스타일 수정

### DIFF
--- a/src/components/Story/LikeButton.tsx
+++ b/src/components/Story/LikeButton.tsx
@@ -4,15 +4,20 @@ import { IconButton } from '@mui/material';
 
 import useLike from '../../hooks/useLike';
 import { Like } from '../../interfaces/like';
+import { User } from '../../interfaces/user';
 
 interface Props {
-  userId: string;
+  user?: User;
   likes: Like[];
   storyId: string;
 }
 
-const LikeButton = ({ userId, likes, storyId }: Props) => {
-  const { isLike, likeCount, handleClick } = useLike(userId, likes, storyId);
+const LikeButton = ({ user, likes, storyId }: Props) => {
+  const { isLike, likeCount, handleClick } = useLike(
+    user?._id || '',
+    likes,
+    storyId
+  );
 
   return (
     <IconButton onClick={handleClick}>

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -1,11 +1,5 @@
 import styled from '@emotion/styled';
-import {
-  Avatar,
-  Button,
-  CircularProgress,
-  Paper,
-  Typography,
-} from '@mui/material';
+import { Avatar, Button, Paper, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useNavigate } from 'react-router-dom';
 
@@ -26,22 +20,15 @@ const StoryInfo = ({ story }: Props) => {
 
   const { storyTitle, year, month, day, content } = JSON.parse(story.title);
 
-  if (isLoading) return <CircularProgress />;
-
   return (
     <>
       <Box>
-        <Typography
-          variant='h3'
-          gutterBottom
-          sx={{ fontSize: '2rem', fontWeight: '500' }}>
-          {storyTitle}
-        </Typography>
+        <h1>{storyTitle}</h1>
         <DateContainer>
           <Typography variant='subtitle1'>
             {year}년 {month}월 {day}일
           </Typography>
-          {user && user._id === story.author._id && (
+          {!isLoading && user?._id === story.author._id && (
             <Box>
               <Button
                 variant='text'
@@ -126,7 +113,7 @@ const StoryImage = styled.img`
 
 const StoryContentWrapper = styled(Paper)`
   min-width: 90%;
-  padding: 25px;
+  padding: 15px;
   margin: 15px 0;
   line-height: 1.5rem;
   word-break: keep-all;

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -66,12 +66,8 @@ const StoryInfo = ({ story }: Props) => {
             {content}
           </StoryContentWrapper>
         )}
-        {!isLoading && user && (
-          <LikeButton
-            userId={user._id}
-            storyId={story._id}
-            likes={story.likes}
-          />
+        {!isLoading && (
+          <LikeButton user={user} storyId={story._id} likes={story.likes} />
         )}
       </StoryContainer>
     </>

--- a/src/components/StoryEdit/DatePicker.tsx
+++ b/src/components/StoryEdit/DatePicker.tsx
@@ -1,7 +1,12 @@
-import { TextField } from '@mui/material';
+import 'dayjs/locale/ko';
+
+import { createTheme, TextField, ThemeProvider } from '@mui/material';
+import {
+  koKR,
+  LocalizationProvider,
+  MobileDatePicker,
+} from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import dayjs, { Dayjs } from 'dayjs';
 
 interface Props {
@@ -11,16 +16,38 @@ interface Props {
 
 const DatePicker = ({ value, onChange }: Props) => {
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <MobileDatePicker
-        inputFormat='YYYY/MM/DD'
-        value={value}
-        onChange={onChange}
-        renderInput={(params) => <TextField {...params} />}
-        maxDate={dayjs(new Date())}
-      />
-    </LocalizationProvider>
+    <ThemeProvider theme={theme}>
+      <LocalizationProvider
+        dateAdapter={AdapterDayjs}
+        adapterLocale='ko'
+        localeText={
+          koKR.components.MuiLocalizationProvider.defaultProps.localeText
+        }>
+        <MobileDatePicker
+          inputFormat='YYYY년 M월 D일'
+          label='날짜'
+          value={value}
+          toolbarFormat='YYYY년 M월 D일'
+          onChange={onChange}
+          disableMaskedInput
+          renderInput={(params) => <TextField {...params} />}
+          maxDate={dayjs(new Date())}
+        />
+      </LocalizationProvider>
+    </ThemeProvider>
   );
 };
 
 export default DatePicker;
+
+const theme = createTheme({
+  components: {
+    MuiTypography: {
+      styleOverrides: {
+        root: {
+          fontSize: '1rem',
+        },
+      },
+    },
+  },
+});

--- a/src/components/StoryEdit/ImageUpload.tsx
+++ b/src/components/StoryEdit/ImageUpload.tsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled';
+import { Box, Button } from '@mui/material';
+import { ChangeEvent, DragEvent, useRef, useState } from 'react';
+
+interface Props {
+  src: string;
+  onChange: (file: File) => void;
+  onDelete: () => void;
+}
+
+const ImageUpload = ({ src, onChange, onDelete }: Props) => {
+  const [currentImage, setCurrentImage] = useState<File>();
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setCurrentImage(file);
+      onChange(file);
+    }
+  };
+
+  const handleChooseFile = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  const handleDragEnter = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.dataTransfer.items?.length > 0) {
+      setDragging(true);
+    }
+  };
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setDragging(false);
+  };
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  const handleFileDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      setCurrentImage(file);
+      onChange(file);
+    }
+  };
+
+  return (
+    <>
+      <UploadContainer
+        sx={{
+          borderColor: dragging ? 'black' : 'grey',
+        }}
+        onClick={handleChooseFile}
+        onDrop={handleFileDrop}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}>
+        <input
+          hidden
+          ref={inputRef}
+          type='file'
+          name='Story Image'
+          accept='image/jpg, image/jpeg, image/png'
+          onChange={handleFileChange}
+        />
+        {src ? (
+          <ImagePreview src={src} alt='story image' />
+        ) : (
+          <ImagePlaceholder>
+            클릭하여 이미지를 추가하거나
+            <br />
+            이미지를 드래그하세요
+          </ImagePlaceholder>
+        )}
+      </UploadContainer>
+      {(src || currentImage) && <Button onClick={onDelete}>삭제</Button>}
+    </>
+  );
+};
+
+export default ImageUpload;
+
+const UploadContainer = styled(Box)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 300px;
+  border: 1px dashed grey;
+`;
+
+const ImagePlaceholder = styled.div`
+  color: grey;
+  text-align: center;
+  line-height: 1.4rem;
+`;
+
+const ImagePreview = styled.img`
+  max-width: 100%;
+  height: 300px;
+  object-fit: contain;
+`;

--- a/src/components/StoryEdit/StoryEditForm.tsx
+++ b/src/components/StoryEdit/StoryEditForm.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 import { useStoryForm } from '../../hooks/useStory';
 import { StoryData } from '../../interfaces/story';
 import DatePicker from './DatePicker';
-import ImageInput from './ImageInput';
+import ImageUpload from './ImageUpload';
 import SubmitButton from './SubmitButton';
 import TextInput from './TextInput';
 
@@ -43,43 +43,38 @@ const StoryEditForm = ({ story }: Props) => {
   return (
     <form onSubmit={(e) => handleSubmit(e, story.imagePublicId)}>
       <Section>
-        <Label>날짜</Label>
         <Box sx={{ width: '100%' }}>
           <DatePicker value={date} onChange={handleDateChange} />
         </Box>
       </Section>
       <Section>
-        <Label>제목</Label>
         <InputDiv>
           <TextInput
             name='title'
             value={values.title}
-            placeholder='스토리의 제목을 입력하세요.'
+            placeholder='스토리의 제목을 입력하세요'
             onChange={handleChange}
           />
           <ErrorText>{errors.title}</ErrorText>
         </InputDiv>
       </Section>
       <Section>
-        <Label>사진</Label>
         <InputDiv>
-          <ImageInput
+          <ImageUpload
+            src={image}
             onChange={handleImageChange}
             onDelete={handleImageDelete}
-            isAdded={image !== ''}
           />
-          <div>{image && <ImagePreview src={image} alt='preview image' />}</div>
         </InputDiv>
       </Section>
       <Section>
-        <Label>내용</Label>
         <InputDiv>
           <TextInput
             name='content'
             value={values.content}
             multiline
             rows={10}
-            placeholder='스토리의 내용을 입력하세요.'
+            placeholder='스토리의 내용을 입력하세요'
             onChange={handleChange}
           />
           <ErrorText>{errors.content}</ErrorText>
@@ -97,18 +92,9 @@ const Section = styled(Box)`
   padding-bottom: 20px;
 `;
 
-const Label = styled.label`
-  width: 50px;
-`;
-
 const InputDiv = styled(Box)`
   width: 100%;
-`;
-
-const ImagePreview = styled.img`
-  max-width: 100%;
-  height: 300px;
-  object-fit: contain;
+  text-align: right;
 `;
 
 const ErrorText = styled.small`

--- a/src/hooks/useStory.ts
+++ b/src/hooks/useStory.ts
@@ -25,7 +25,6 @@ export const useFetchStory = () => {
     updatedAt: '',
   });
   const [isLoading, setIsLoading] = useState(false);
-  const [isNew, setIsNew] = useState(false);
   const { storyId } = useParams();
   const navigate = useNavigate();
 
@@ -37,19 +36,16 @@ export const useFetchStory = () => {
           navigate(ROUTES.NOT_FOUND);
           return;
         }
+        if (storyId === 'new') return;
 
-        if (storyId === 'new') {
-          setIsNew(true);
-        } else {
-          const stories = await getStoriesOfChannel(channelId);
-          if (!stories.find((story: Story) => story._id === storyId)) {
-            alert('존재하지 않는 스토리입니다.');
-            navigate(ROUTES.HOME);
-          }
-
-          const storyDetail = await getStoryDetail(storyId);
-          setStory(storyDetail);
+        const stories = await getStoriesOfChannel(channelId);
+        if (!stories.find((story: Story) => story._id === storyId)) {
+          alert('존재하지 않는 스토리입니다.');
+          navigate(ROUTES.HOME);
         }
+
+        const storyDetail = await getStoryDetail(storyId);
+        setStory(storyDetail);
       } catch (error) {
         console.error(error);
         alert(ERROR_MESSAGES.INVOKED_ERROR_GETTING_STORY);
@@ -73,7 +69,7 @@ export const useFetchStory = () => {
     }
   };
 
-  return { story, isNew, isLoading, fetchComment };
+  return { story, isLoading, fetchComment };
 };
 
 const getDateInfo = (date: Dayjs) => ({
@@ -140,10 +136,9 @@ export const useStoryForm = (initialValues: StoryInfo | undefined) => {
     });
   };
 
-  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files) return;
-    setImageFile(e.target.files?.[0]);
-    encodeFileToBase64(e.target.files?.[0]);
+  const handleImageChange = (imageFile: File) => {
+    setImageFile(imageFile);
+    encodeFileToBase64(imageFile);
   };
 
   const handleImageDelete = () => {

--- a/src/pages/Story.tsx
+++ b/src/pages/Story.tsx
@@ -1,14 +1,15 @@
 import styled from '@emotion/styled';
-import { Box, CircularProgress, Divider } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 
 import StoryComment from '../components/Story/StoryComment';
 import StoryInfo from '../components/Story/StoryInfo';
+import Loading from '../components/StoryBook/Loading';
 import { useFetchStory } from '../hooks/useStory';
 
 const Story = () => {
   const { story, fetchComment, isLoading } = useFetchStory();
 
-  if (isLoading || !story.title) return <CircularProgress />;
+  if (isLoading || !story.title) return <Loading />;
 
   return (
     <Container>

--- a/src/pages/StoryEdit.tsx
+++ b/src/pages/StoryEdit.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
-import { CircularProgress } from '@mui/material';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import Loading from '../components/StoryBook/Loading';
 import StoryEditForm from '../components/StoryEdit/StoryEditForm';
 import { ROUTES } from '../constants/routes';
 import useFetchUser from '../hooks/useFetchUser';
@@ -10,8 +10,16 @@ import { useFetchStory } from '../hooks/useStory';
 
 const StoryEdit = () => {
   const { user, isLoading: isUserLoading } = useFetchUser();
-  const { story, isNew, isLoading: isStoryLoading } = useFetchStory();
+  const { story, isLoading: isStoryLoading } = useFetchStory();
+  const [title, setTitle] = useState('');
+  const { storyId } = useParams();
   const navigate = useNavigate();
+
+  const isNew = storyId === 'new';
+
+  useLayoutEffect(() => {
+    setTitle(`스토리 ${isNew ? '추가' : '수정'}`);
+  }, [storyId]);
 
   useEffect(() => {
     if (isNew || isUserLoading || isStoryLoading) return;
@@ -22,11 +30,11 @@ const StoryEdit = () => {
     }
   }, [user, story]);
 
-  if (isUserLoading || isStoryLoading) return <CircularProgress />;
+  if (isUserLoading || isStoryLoading) return <Loading />;
 
   return (
     <Container>
-      <h1>{!isNew || story._id ? '스토리 수정' : '스토리 추가'}</h1>
+      <h1>{title}</h1>
       <StoryEditForm story={story} />
     </Container>
   );


### PR DESCRIPTION
## 이슈 번호가 있다면 적어주세요
#90 

## 작업 목록
- 스토리 이미지 업로드 방식 추가(드래그 앤 드롭)
- StoryEdit 페이지 레이아웃 수정
- '스토리 추가'와 '스토리 수정' 타이틀이 새로고침 시 깜빡거리는 현상 해결(useLayoutEffect)
- DatePicker 스타일 수정, 한국어 설정

### 참고 사진이 있다면 첨부
<img width="50%" src="https://user-images.githubusercontent.com/63575891/212753669-5e00716c-cc3c-4f53-a2d7-952b087623a3.png" />

## 예정

## 궁금한 점
