### PR TITLE
로그인 폼에서 비밀번호 변경 링크 제거

### DIFF
--- a/src/components/SignIn/SignInLinks.tsx
+++ b/src/components/SignIn/SignInLinks.tsx
@@ -1,4 +1,4 @@
-import { Grid, Link } from '@mui/material';
+import { Container, Link } from '@mui/material';
 
 interface Props {
   onClick: () => void;
@@ -6,19 +6,13 @@ interface Props {
 
 const SignInLinks = ({ onClick }: Props) => {
   return (
-    <Grid container sx={{ marginTop: '1rem' }}>
-      {/* todo: 비밀번호 변경 페이지 및 api 개발 */}
-      <Grid item xs>
-        <Link variant='body2' sx={{ cursor: 'pointer' }}>
-          비밀번호 또 까먹음?
-        </Link>
-      </Grid>
-      <Grid item onClick={onClick}>
-        <Link variant='body2' sx={{ cursor: 'pointer' }}>
-          <span>계정도 없음?</span>
-        </Link>
-      </Grid>
-    </Grid>
+    <Container
+      sx={{ textAlign: 'center', marginTop: '1rem' }}
+      onClick={onClick}>
+      <Link variant='body2' sx={{ cursor: 'pointer' }}>
+        <span>아직도 계정 없음?</span>
+      </Link>
+    </Container>
   );
 };
 

--- a/src/hooks/useCheckAuthToken.ts
+++ b/src/hooks/useCheckAuthToken.ts
@@ -4,21 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { TOKEN_KEY } from '../constants/auth';
 import { ROUTES } from '../constants/routes';
 import { getLocalStorage } from '../utils/storage';
-import { checkAuth } from './../apis/auth';
 
 const useCheckAuthToken = () => {
   const navigate = useNavigate();
   const token = getLocalStorage(TOKEN_KEY);
 
   useEffect(() => {
-    const fetchIsOnline = async () => {
-      const { isOnline } = await checkAuth();
-
-      token && isOnline && navigate(ROUTES.HOME);
-    };
-
-    fetchIsOnline();
-  }, []);
+    token && navigate(ROUTES.HOME);
+  });
 };
 
 export default useCheckAuthToken;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import { Container, Divider, Grid, Link } from '@mui/material';
+import { Container, Divider } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
 import SignInForm from '../components/SignIn/SignInForm';


### PR DESCRIPTION
#45

## 작업 목록
- 로그인 폼에서 비밀번호 변경 링크 제거
- useCheckAuthToken 훅에서 isOnline 제거
  - token 확인해서 리다이렉팅 시키는 것 뿐인데 checkAuth api를 날리면 isOnline이 자동으로 true가 되어 제거.

### 참고 사진이 있다면 첨부
![image](https://user-images.githubusercontent.com/93233930/212853516-80f1be72-a1ec-472c-a938-2c72c7cb9973.png)

