### PR TITLE
StoryBook 페이지에서 rootMargin, threshold를 변경해 보이지 않더라도 어느정도의 사진은 불러오기

### DIFF
--- a/src/components/StoryBook/Empty.tsx
+++ b/src/components/StoryBook/Empty.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import { Typography } from '@mui/material';
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+const Empty = ({ children }: Props) => {
+  return <CustomTypography>{children}</CustomTypography>;
+};
+
+export default Empty;
+
+const CustomTypography = styled(Typography)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, 50%);
+`;

--- a/src/hooks/useLazyLoadImage.ts
+++ b/src/hooks/useLazyLoadImage.ts
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState } from 'react';
 
 const LOAD_IMAGE_EVENT_TYPE = 'loadImage';
 
+const observerOptions = {
+  rootMargin: '200px',
+  threshold: 0.1,
+};
+
 const useLazyLoadImage = (lazy = false) => {
   const [loaded, setLoaded] = useState(false);
   const imageRef = useRef<HTMLImageElement>(null);
@@ -38,9 +43,7 @@ const useLazyLoadImage = (lazy = false) => {
           }
         });
       },
-      {
-        threshold: 0.3,
-      }
+      observerOptions
     );
 
     imageRef.current && observer.observe(imageRef.current);

--- a/src/pages/StoryBook.tsx
+++ b/src/pages/StoryBook.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import Empty from '../components/StoryBook/Empty';
 import Loading from '../components/StoryBook/Loading';
 import StoriesByYear from '../components/StoryBook/StoriesByYear';
 import StoryBookTitle from '../components/StoryBook/StoryBookTitle';
@@ -14,9 +15,13 @@ const StoryBook = () => {
     <Container>
       <StoriesContainer>
         {!!fullName && <StoryBookTitle fullName={fullName} />}
-        {storiesByYear.map(({ year, stories }) => (
-          <StoriesByYear key={year} year={year} stories={stories} />
-        ))}
+        {storiesByYear.length !== 0 ? (
+          storiesByYear.map(({ year, stories }) => (
+            <StoriesByYear key={year} year={year} stories={stories} />
+          ))
+        ) : (
+          <Empty>{fullName}님은 게으른가봐요. ㅋ</Empty>
+        )}
       </StoriesContainer>
     </Container>
   );


### PR DESCRIPTION
#22

## 작업 목록
- StoryBook 페이지에서 rootMargin, threshold를 변경해 보이지 않더라도 어느정도의 사진은 불러오기
- StoryBook에서 스토리가 하나도 없을 경우 Empty 컴포넌트 출력

### 참고 사진이 있다면 첨부
- 기존
![before](https://user-images.githubusercontent.com/93233930/212859020-3418f41c-42f8-4211-9741-53d70ed93201.gif)

<br />

- 변경
![after](https://user-images.githubusercontent.com/93233930/212859029-cf41da87-8ce2-4eab-a132-e1216283082a.gif)

<br />

- 스토리가 하나도 없을 경우
![image](https://user-images.githubusercontent.com/93233930/212864307-5167fc81-fdeb-43df-813a-2fb93f0eeb74.png)

## 예정
문구는 적절한 것이 있으면 변경할 예정입니다.

