### PR TITLE
홈 화면, 스토리북에서 스크롤에 의해 발생하는 레이아웃 쉬프트 제거

### DIFF
--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -140,9 +140,9 @@ const Hamburger = styled.nav<{ click: boolean }>`
 `;
 
 const HamburgerButton = styled.div`
-  cursor: pointer;
   width: 1.5rem;
   height: 1.5rem;
+  cursor: pointer;
 `;
 
 const Logo = styled.h1`

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -141,6 +141,8 @@ const Hamburger = styled.nav<{ click: boolean }>`
 
 const HamburgerButton = styled.div`
   cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
 `;
 
 const Logo = styled.h1`

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -17,7 +17,7 @@ const style = css`
   }
   body {
     margin: 0;
-    overflow-y: scroll;
+    /* overflow-y: scroll; */
   }
   main {
     display: block;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -17,6 +17,7 @@ const style = css`
   }
   body {
     margin: 0;
+    overflow-y: scroll;
   }
   main {
     display: block;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -17,7 +17,7 @@ const style = css`
   }
   body {
     margin: 0;
-    /* overflow-y: scroll; */
+    overflow-y: scroll;
   }
   main {
     display: block;


### PR DESCRIPTION
#132

## 작업 목록
- 스크롤에 의해 발생하는 레이아웃 쉬프트 제거
- 햄버거 버튼에 넓이랑 높이 부여

### 참고 사진이 있다면 첨부
- 기존(처음 렌더링 될 때 양 옆으로 흔들림)
![before](https://user-images.githubusercontent.com/93233930/212895255-7ad4ab00-12bf-4239-8f94-fd5ad228c1d8.gif)

<br />

- 변경
![after](https://user-images.githubusercontent.com/93233930/212895292-8b30e71c-418d-4184-9ce6-bfd311463912.gif)

- 원래는 다음 링크들 내용 활용해서 해결해보려 했는데 저희꺼에는 제가 뭘 잘못한 건지 안 먹히네요...

https://maxschmitt.me/posts/react-prevent-layout-shift-body-scrollable/
https://runebook.dev/ko/docs/css/scrollbar-gutter

- lighthouse
  
![image](https://user-images.githubusercontent.com/93233930/212899474-7b3101cb-807a-4c83-aa28-30d72dbb0bc2.png)
  
![image](https://user-images.githubusercontent.com/93233930/212899528-a7a929d8-4dc5-4122-a3cf-3e40a4c7c3de.png)

CLS는 0.003 감소..! 낮을 수록 좋은거 맞나요? ㅋㅋㅋ


## 궁금한 점
- 이렇게 하면 레이아웃 쉬프트를 없앨 수는 있지만 평상시에도 밑의 빈? 스크롤 정도는 항상 있게 됩니다. 모바일에서는 잠시 배포해서 확인해보니까 상관없네요. 어떻게 생각하시나욥!? (오른쪽 자세히 보면 thumb가 생략된 빈 스크롤이 있어요)
![image](https://user-images.githubusercontent.com/93233930/212895983-fa54b2ee-429e-4e3b-8710-7fbd86e838fc.png)

 
