### PR TITLE
프로필 수정 정보 추가 및 로직 변경, 햄버거 메뉴 프로필 이미지와 닉네임 표시

### DIFF
--- a/src/components/Profile/ImageForm.tsx
+++ b/src/components/Profile/ImageForm.tsx
@@ -8,19 +8,19 @@ import ImageUpload from '../StoryEdit/ImageUpload';
 
 interface Props {
   type: string;
-  image: string;
+  oldImage: string;
   open: boolean;
   handleOpen: () => void;
 }
 
-const ImageForm = ({ type, image, open, handleOpen }: Props) => {
-  const [imageBase64, setImageBase64] = useState(image);
+const ImageForm = ({ type, oldImage, open, handleOpen }: Props) => {
+  const [imageBase64, setImageBase64] = useState(oldImage);
   const [imageFile, setImageFile] = useState<File | null>();
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    setImageBase64(image);
+    setImageBase64(oldImage);
     setError('');
   }, [open]);
 
@@ -93,9 +93,23 @@ const ImageForm = ({ type, image, open, handleOpen }: Props) => {
         />
         <ErrorText>{error}</ErrorText>
       </InputWrapper>
-      <Button type='submit' variant='contained' disabled={isLoading} fullWidth>
-        {type} 이미지 변경
-      </Button>
+      <ButtonWrapper>
+        <Button
+          type='button'
+          variant='outlined'
+          disabled={isLoading}
+          fullWidth
+          onClick={handleOpen}>
+          취소
+        </Button>
+        <Button
+          type='submit'
+          variant='contained'
+          disabled={isLoading}
+          fullWidth>
+          {type} 이미지 변경
+        </Button>
+      </ButtonWrapper>
     </form>
   );
 };
@@ -109,4 +123,8 @@ const InputWrapper = styled.div`
 
 const ErrorText = styled.small`
   color: red;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
 `;

--- a/src/components/Profile/PasswordForm.tsx
+++ b/src/components/Profile/PasswordForm.tsx
@@ -27,6 +27,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState(initialErrors);
   const [isLoading, setIsLoading] = useState(false);
+  const passwordRegex = /^.{6,15}$/;
 
   useEffect(() => {
     setValues(initialValues);
@@ -48,7 +49,10 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
       errors.newValue = '새 비밀번호를 입력해 주세요.';
     else if (oldValue === newValue) {
       errors.newValue = '현재 비밀번호와 일치합니다.';
+    } else if (!passwordRegex.test(newValue)) {
+      errors.newValue = '비밀번호는 6자리 이상, 15자리 이하로 입력해주세요';
     }
+
     if (isBlankString(newValueCheck))
       errors.newValueCheck = '새 비밀번호 확인을 입력해 주세요.';
     else if (newValue !== newValueCheck)
@@ -103,6 +107,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           type='password'
           name='newValue'
           label='새 비밀번호'
+          placeholder='6-15자리'
           size='small'
           error={!!errors.newValue}
           helperText={errors.newValue}
@@ -122,9 +127,23 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           onChange={handleChange}
         />
       </InputWrapper>
-      <Button type='submit' variant='contained' disabled={isLoading} fullWidth>
-        비밀번호 변경
-      </Button>
+      <ButtonWrapper>
+        <Button
+          type='button'
+          variant='outlined'
+          disabled={isLoading}
+          fullWidth
+          onClick={handleOpen}>
+          취소
+        </Button>
+        <Button
+          type='submit'
+          variant='contained'
+          disabled={isLoading}
+          fullWidth>
+          비밀번호 변경
+        </Button>
+      </ButtonWrapper>
     </Form>
   );
 };
@@ -139,4 +158,8 @@ const Form = styled.form`
 const InputWrapper = styled.div`
   width: 100%;
   padding-bottom: 13px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
 `;

--- a/src/components/Profile/ProfileModal.tsx
+++ b/src/components/Profile/ProfileModal.tsx
@@ -58,7 +58,7 @@ const ProfileModal = ({ type, user, open, handleOpen }: Props) => {
       form: (
         <ImageForm
           type='커버'
-          image={user.coverImage || ''}
+          oldImage={user.coverImage || ''}
           open={open}
           handleOpen={handleOpen}
         />
@@ -69,7 +69,7 @@ const ProfileModal = ({ type, user, open, handleOpen }: Props) => {
       form: (
         <ImageForm
           type='프로필'
-          image={user.image || ''}
+          oldImage={user.image || ''}
           open={open}
           handleOpen={handleOpen}
         />
@@ -97,6 +97,7 @@ const ContentWrapper = styled(Box)`
   position: absolute;
   width: 50%;
   min-width: 300px;
+  max-width: 500px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/src/components/Profile/TextForm.tsx
+++ b/src/components/Profile/TextForm.tsx
@@ -31,6 +31,7 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const fullNameRegex = /^[A-Za-z0-9가-힣]{4,12}$/;
 
   useEffect(() => {
     setError('');
@@ -44,19 +45,24 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
     e.preventDefault();
     setIsLoading(true);
 
-    if (!value || isBlankString(value)) {
-      setError(`${type}을 입력해 주세요`);
-      setIsLoading(false);
-      return;
-    }
+    const validate = () => {
+      let newError = '';
+      if (!value || isBlankString(value)) newError = `${type}을 입력해 주세요`;
+      else if (value === initialValue) newError = `현재 ${type}과 같습니다`;
+      else if (type === '닉네임' && !fullNameRegex.test(value))
+        newError = '영어, 숫자, 한글만 입력가능합니다.(4-12자리)';
 
-    if (value === initialValue) {
-      setError(`현재 ${type}과 같습니다`);
-      setIsLoading(false);
-      return;
-    }
+      return newError;
+    };
 
     try {
+      const newError = validate();
+      if (newError) {
+        setError(newError);
+        setIsLoading(false);
+        return;
+      }
+
       if (type === '닉네임') {
         await putUserInfo(
           value,
@@ -97,9 +103,23 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
         onChange={handleChange}
         sx={{ marginBottom: '20px' }}
       />
-      <Button type='submit' variant='contained' disabled={isLoading} fullWidth>
-        {type} 변경
-      </Button>
+      <ButtonWrapper>
+        <Button
+          type='button'
+          variant='outlined'
+          disabled={isLoading}
+          fullWidth
+          onClick={handleOpen}>
+          취소
+        </Button>
+        <Button
+          type='submit'
+          variant='contained'
+          disabled={isLoading}
+          fullWidth>
+          {type} 변경
+        </Button>
+      </ButtonWrapper>
     </Form>
   );
 };
@@ -108,4 +128,8 @@ export default TextForm;
 
 const Form = styled.form`
   margin: 15px 0;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
 `;

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -34,7 +34,6 @@ const Header = () => {
     };
 
     fetchUser();
-    console.log(user);
   }, [token]);
 
   const handleClickProfileButton = () => {

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Avatar } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -6,7 +7,6 @@ import { checkAuth } from '../../apis/auth';
 import { TOKEN_KEY, USER_ID_KEY } from '../../constants/auth';
 import { COLORS } from '../../constants/colors';
 import { ROUTES } from '../../constants/routes';
-import useFetchUser from '../../hooks/useFetchUser';
 import { getLocalStorage, removeLocalStorage } from '../../utils/storage';
 import NotificationButton from '../Alarm/NotificationButton';
 import FontText from '../Home/FontText';
@@ -14,18 +14,28 @@ import StoryAddButton from '../StoryBook/StoryAddButton';
 
 const Header = () => {
   const [click, setClick] = useState(false);
-  const [image, setImage] = useState('');
-  const [name, setName] = useState('');
   const handleClick = () => setClick(!click);
   const navigate = useNavigate();
   const token = getLocalStorage(TOKEN_KEY);
-  const { user, isLoading } = useFetchUser();
+  const [user, setUser] = useState({
+    image: '',
+    fullName: '',
+    _id: '',
+  });
 
   useEffect(() => {
-    if (!isLoading) return;
-    user?.image && setImage(user.image);
-    user?.fullName && setName(user.fullName);
-  }, [isLoading, user?._id]);
+    const fetchUser = async () => {
+      const userInfo = await checkAuth();
+      setUser({
+        image: userInfo.image,
+        fullName: userInfo.fullName,
+        _id: userInfo._id,
+      });
+    };
+
+    fetchUser();
+    console.log(user);
+  }, [token]);
 
   const handleClickProfileButton = () => {
     token ? navigate(ROUTES.PROFILE) : navigate(ROUTES.SIGNIN);
@@ -37,8 +47,7 @@ const Header = () => {
 
   const handleClickMyStoryButton = async () => {
     if (token) {
-      const { _id: userId } = await checkAuth();
-      navigate(ROUTES.STORY_BOOK_BY_USER_ID(userId));
+      navigate(ROUTES.STORY_BOOK_BY_USER_ID(user._id));
       return;
     }
 
@@ -47,8 +56,7 @@ const Header = () => {
 
   const handleClickFollowListButton = async () => {
     if (token) {
-      const { _id: userId } = await checkAuth();
-      navigate(ROUTES.FOLLOW_BY_USER_ID(userId));
+      navigate(ROUTES.FOLLOW_BY_USER_ID(user._id));
       return;
     }
 
@@ -89,8 +97,12 @@ const Header = () => {
       </ButtonsContainer>
       <Hamburger onClick={handleClick} click={click}>
         <NavLinks onClick={handleClickProfileButton}>
-          <img src={image || '/icons/user_profile.svg'} width={120} />
-          <p>{name}</p>
+          <Avatar
+            src={user.image || ''}
+            alt='profile image'
+            sx={{ width: '120px', height: '120px' }}
+          />
+          {user.fullName && <p>{user.fullName}</p>}
         </NavLinks>
         <NavLinks onClick={handleClickWatchStoriesButton}>
           스토리 구경하기
@@ -169,7 +181,7 @@ const Logo = styled.h1`
 
 const NavLinks = styled.div`
   font-size: 1rem;
-  padding: 2rem;
+  padding: 1.5rem 0;
   font-weight: bold;
   cursor: pointer;
   p {

--- a/src/hooks/useLike.ts
+++ b/src/hooks/useLike.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { deleteStoryLike } from '../apis/story';
 import { ERROR_MESSAGES } from '../constants/errorMessages';
-import { ROUTES } from '../constants/routes';
 import { Like } from '../interfaces/like';
 import { postNotification } from './../apis/notification';
 import { postStoryLike } from './../apis/story';
@@ -17,7 +15,6 @@ const useLike = (
   const [isLike, setIsLike] = useState(false);
   const [likeId, setLikeId] = useState('');
   const [likeCount, setLikeCount] = useState(storyLikes.length);
-  const navigate = useNavigate();
 
   useEffect(() => {
     const findStoryLike = storyLikes.find((data) => data.user === userId);
@@ -30,7 +27,6 @@ const useLike = (
   const handleClick = async () => {
     if (!userId) {
       alert('로그인 후 이용해 주세요.');
-      navigate(ROUTES.SIGNIN);
       return;
     }
 

--- a/src/hooks/useStory.ts
+++ b/src/hooks/useStory.ts
@@ -42,6 +42,7 @@ export const useFetchStory = () => {
         if (!stories.find((story: Story) => story._id === storyId)) {
           alert('존재하지 않는 스토리입니다.');
           navigate(ROUTES.HOME);
+          return;
         }
 
         const storyDetail = await getStoryDetail(storyId);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -53,7 +53,7 @@ const Profile = () => {
     <Container>
       <ImageContainer>
         <CoverImageWrapper>
-          <CoverImage src={coverImage || ''} alt='cover image' />
+          <CoverImage image={coverImage || ''} />
           <Button
             data-type='coverImage'
             onClick={handleModalType}
@@ -94,7 +94,7 @@ const Profile = () => {
               수정
             </Button>
           </InfoListItem>
-          {date.year && (
+          {date?.year && (
             <InfoListItem sx={{ alignItems: 'baseline' }}>
               <ListItemText primary='생년월일' />
               <span>
@@ -159,11 +159,13 @@ const CoverImageWrapper = styled.div`
   position: relative;
 `;
 
-const CoverImage = styled.img<{ src: string }>`
+const CoverImage = styled.div<{ image: string }>`
   width: 100%;
   height: 200px;
-  background: ${(props) => (props.src ? `url(${props.src})` : 'lightgray')};
-  object-fit: cover;
+  background: ${(props) => (props.image ? `url(${props.image})` : 'lightgray')};
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: 50%;
 `;
 
 const ProfileImageWrapper = styled.div`


### PR DESCRIPTION
# 이슈 번호가 있다면 적어주세요
#140 

## 작업 목록
- 프로필 수정 정보 추가 및 로직 변경
  - 비밀번호와 닉네임 유효성 검사 회원가입과 동일하게 적용
  - 이메일 주소과 생년월일 추가
- 커버 이미지 레이아웃 수정(이미지 없을 경우 회색 배경)
- 이미지 수정 시 미리보기 이미지 안 보이는 에러 해결
- 햄버거 메뉴 프로필 이미지와 닉네임 표시

### 참고 사진이 있다면 첨부
<img width="50%" alt="스크린샷 2023-01-18 오후 11 26 42" src="https://user-images.githubusercontent.com/63575891/213196951-bd0a8b63-c936-4052-8ea3-f05987fe7395.png">
<img width="50%" alt="스크린샷 2023-01-18 오후 11 28 04" src="https://user-images.githubusercontent.com/63575891/213197313-aef195b6-8f44-4b28-9357-91872b3692ad.png">
<img width="50%" alt="스크린샷 2023-01-18 오후 11 34 10" src="https://user-images.githubusercontent.com/63575891/213198821-25019e9f-de47-49b4-9cd9-5a47297af148.png">

## 예정

## 궁금한 점
