### PR TITLE
페이지 로딩 시간 약 2초 감소

### DIFF
--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -34,7 +34,9 @@ const StoryInfo = ({ story }: Props) => {
                 variant='text'
                 color='warning'
                 onClick={() =>
-                  navigate(ROUTES.STORY_EDIT_BY_STORY_ID(story._id))
+                  navigate(ROUTES.STORY_EDIT_BY_STORY_ID(story._id), {
+                    state: story,
+                  })
                 }>
                 수정
               </Button>

--- a/src/components/StoryEdit/StoryEditForm.tsx
+++ b/src/components/StoryEdit/StoryEditForm.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
+import { useLocation } from 'react-router-dom';
 
 import { useStoryForm } from '../../hooks/useStory';
 import { StoryData } from '../../interfaces/story';
@@ -10,20 +11,26 @@ import TextInput from './TextInput';
 
 interface Props {
   story: StoryData;
+  isNew: boolean;
 }
 
-const StoryEditForm = ({ story }: Props) => {
-  let initialValues;
+const setInitialValues = (story: StoryData) => {
   if (story._id) {
     const { storyTitle, year, month, day, content } = JSON.parse(story.title);
 
-    initialValues = {
+    return {
       title: storyTitle,
       date: { year: Number(year), month: Number(month), date: Number(day) },
       imageURL: story.image,
       content,
     };
   }
+};
+
+const StoryEditForm = ({ story, isNew }: Props) => {
+  const { state } = useLocation();
+
+  const initialValues = setInitialValues(isNew ? story : state);
 
   const {
     values,

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -104,19 +104,14 @@ const Header = () => {
           handleClickHamburgerClose();
           navigate(ROUTES.HOME);
         }}>
-        <FontText
-          title='Bigtoria'
-          sx={{
-            fontSize: '1.25rem',
-          }}
-        />
+        Bigtoria
       </Logo>
       <ButtonsContainer>
-        <StoryAddButton onClick={handleClickHamburgerClose} />
-        <NotificationButton onClick={handleClickHamburgerClose} />
         <HamburgerButton onClick={handleClick}>
           {click ? <FaArrowRight fontSize={'1.25rem'} /> : <FaHamburger />}
         </HamburgerButton>
+        <NotificationButton onClick={handleClickHamburgerClose} />
+        <StoryAddButton onClick={handleClickHamburgerClose} />
       </ButtonsContainer>
       <Hamburger onClick={handleClick} click={click}>
         <NavLinks onClick={handleClickProfileButton}>
@@ -150,6 +145,7 @@ const Container = styled.header<{ isScrolled: boolean }>`
   top: 0;
   padding: 1.2rem 1rem;
   display: flex;
+  flex-direction: row-reverse;
   align-items: center;
   justify-content: space-between;
   z-index: 999;
@@ -166,14 +162,14 @@ const ButtonsContainer = styled.div`
 
 const Hamburger = styled.nav<{ click: boolean }>`
   width: 100%;
-  display: ${({ click }) => (click ? 'flex' : 'none')};
+  display: flex;
   gap: 1rem;
   flex-direction: column;
   align-items: center;
   height: 100vh;
   position: absolute;
   top: 3.6rem;
-  right: ${({ click }) => (click ? 0 : '-100%')};
+  left: ${({ click }) => (click ? 0 : '-100%')};
   opacity: ${({ click }) => (click ? 1 : 0)};
   animation-name: slide;
   animation-duration: 0.5s;
@@ -181,15 +177,6 @@ const Hamburger = styled.nav<{ click: boolean }>`
   background: #ffffff;
   z-index: 999;
   padding-top: 4rem;
-
-  @keyframes slide {
-    from {
-      right: -100%;
-    }
-    to {
-      right: 0;
-    }
-  }
 `;
 
 const HamburgerButton = styled.div`
@@ -203,6 +190,8 @@ const HamburgerButton = styled.div`
 
 const Logo = styled.h1`
   margin: 0;
+  font-display: fallback;
+  font-size: 1.25rem;
   cursor: pointer;
 `;
 

--- a/src/pages/StoryEdit.tsx
+++ b/src/pages/StoryEdit.tsx
@@ -1,33 +1,19 @@
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import StoryEditForm from '../components/StoryEdit/StoryEditForm';
-import { ROUTES } from '../constants/routes';
-import useFetchUser from '../hooks/useFetchUser';
 import { useFetchStory } from '../hooks/useStory';
 
 const StoryEdit = () => {
-  const { user, isLoading: isUserLoading } = useFetchUser();
-  const { story, isLoading: isStoryLoading } = useFetchStory();
+  const { story } = useFetchStory();
   const { storyId } = useParams();
-  const navigate = useNavigate();
 
   const isNew = storyId === 'new';
-
-  useEffect(() => {
-    if (isNew || isUserLoading || isStoryLoading) return;
-
-    if (user?._id && user._id !== story.author._id) {
-      alert('올바르지 않은 접근입니다.');
-      navigate(ROUTES.HOME);
-    }
-  }, [user, story]);
 
   return (
     <Container>
       <h1>스토리 {isNew ? '추가' : '수정'}</h1>
-      <StoryEditForm story={story} />
+      <StoryEditForm story={story} isNew={isNew} />
     </Container>
   );
 };

--- a/src/pages/StoryEdit.tsx
+++ b/src/pages/StoryEdit.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import Loading from '../components/StoryBook/Loading';
 import StoryEditForm from '../components/StoryEdit/StoryEditForm';
 import { ROUTES } from '../constants/routes';
 import useFetchUser from '../hooks/useFetchUser';
@@ -11,15 +10,10 @@ import { useFetchStory } from '../hooks/useStory';
 const StoryEdit = () => {
   const { user, isLoading: isUserLoading } = useFetchUser();
   const { story, isLoading: isStoryLoading } = useFetchStory();
-  const [title, setTitle] = useState('');
   const { storyId } = useParams();
   const navigate = useNavigate();
 
   const isNew = storyId === 'new';
-
-  useLayoutEffect(() => {
-    setTitle(`스토리 ${isNew ? '추가' : '수정'}`);
-  }, [storyId]);
 
   useEffect(() => {
     if (isNew || isUserLoading || isStoryLoading) return;
@@ -30,11 +24,9 @@ const StoryEdit = () => {
     }
   }, [user, story]);
 
-  if (isUserLoading || isStoryLoading) return <Loading />;
-
   return (
     <Container>
-      <h1>{title}</h1>
+      <h1>스토리 {isNew ? '추가' : '수정'}</h1>
       <StoryEditForm story={story} />
     </Container>
   );

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -31,21 +31,17 @@ const style = css`
     font-style: normal;
   }
 
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
+  body {
+    font-family: 'MaplestoryOTFLight', cursive;
+    background-color: ${COLORS.MAIN};
+    margin: 0;
+    overflow-y: scroll;
     @media all and (min-width: 768px) {
       width: 412px;
       margin: 0 auto;
     }
   }
-  body {
-    font-family: 'MaplestoryOTFLight', cursive;
 
-    background-color: ${COLORS.MAIN};
-    margin: 0;
-    overflow-y: scroll;
-  }
   main {
     display: block;
   }


### PR DESCRIPTION
## 작업 목록

- [x] 스토리 로직 변경
- [x] prop 전달 방식 분기 변경
- [x] 사용자 대기 시간 제거

### 참고 사진이 있다면 첨부

사용자가 기다리는 시간을 **약 2초** 줄이는 데에 성공했습니다.
데이터가 있으면 더이상 추가 요청을 보내지 않습니다. 사용자는 바로 데이터를 수정할 수 있습니다.

개선 전

![chrome-capture-2023-0-28](https://user-images.githubusercontent.com/77133565/215253218-94d89840-9e2b-473c-bd8f-789a65986088.gif)

개선 후

![chrome-capture-2023-0-28 (1)](https://user-images.githubusercontent.com/77133565/215253295-045c3154-5a24-4a6f-9dd9-12b4d4de7d2d.gif)



## 예정

## 궁금한 점
