### PR TITLE
StoriesByYear에서 key prop 중복되는 현상 관련 임시로 원상 복구

### DIFF
--- a/src/pages/StoryBook.tsx
+++ b/src/pages/StoryBook.tsx
@@ -8,6 +8,7 @@ import useFetchStories from '../hooks/useFetchStories';
 
 const StoryBook = () => {
   const { storiesByYear, fullName, isLoading } = useFetchStories();
+  console.log(storiesByYear);
 
   if (isLoading) return <Loading />;
 
@@ -16,8 +17,8 @@ const StoryBook = () => {
       <StoriesContainer>
         {!!fullName && <StoryBookTitle fullName={fullName} />}
         {storiesByYear.length !== 0 ? (
-          storiesByYear.map(({ year, stories }, i) => (
-            <StoriesByYear key={stories[i]._id} year={year} stories={stories} />
+          storiesByYear.map(({ year, stories }) => (
+            <StoriesByYear key={year} year={year} stories={stories} />
           ))
         ) : (
           <>{!!fullName && <Empty>{fullName}님은 게으른가봐요. ㅋ</Empty>}</>


### PR DESCRIPTION
#22 

## 작업 목록
- StoriesByYear에서 key prop 중복되는 현상 관련 임시로 원상 복구

### 참고
- storiesByYear state 출력시 다음과 같음.
![image](https://user-images.githubusercontent.com/93233930/213358346-102d91f8-68c8-47c2-a62c-707ce2ccc3e1.png)
