### PR TITLE
프로필 이미지 크기 및 모달 창 디자인 수정

### DIFF
--- a/src/components/Profile/ImageForm.tsx
+++ b/src/components/Profile/ImageForm.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Button } from '@mui/material';
+import { Button, Divider, Stack } from '@mui/material';
 import { FormEvent, useEffect, useState } from 'react';
 
 import { postCoverImage, postProfileImage } from '../../apis/userInfo';
@@ -56,12 +56,18 @@ const ImageForm = ({ type, oldImage, open, handleOpen }: Props) => {
     return formData;
   };
 
+  const validate = () => {
+    if (oldImage === imageBase64) return '현재 이미지와 일치합니다.';
+    if (!imageFile) return '이미지를 추가해 주세요.';
+  };
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
 
-    if (!imageFile) {
-      setError('이미지를 추가해 주세요');
+    const error = validate();
+    if (error) {
+      setError(error);
       setIsLoading(false);
       return;
     }
@@ -93,14 +99,22 @@ const ImageForm = ({ type, oldImage, open, handleOpen }: Props) => {
         />
         <ErrorText>{error}</ErrorText>
       </InputWrapper>
-      <ButtonWrapper>
+      <Divider />
+      <Stack
+        direction='row'
+        spacing={0}
+        justifyContent='center'
+        sx={{ width: '100%' }}>
         <Button
           type='button'
           variant='outlined'
           color='warning'
           disabled={isLoading}
-          fullWidth
-          onClick={handleOpen}>
+          size='large'
+          onClick={handleOpen}
+          sx={{
+            width: '50%',
+          }}>
           취소
         </Button>
         <Button
@@ -108,10 +122,10 @@ const ImageForm = ({ type, oldImage, open, handleOpen }: Props) => {
           variant='contained'
           color='warning'
           disabled={isLoading}
-          fullWidth>
+          sx={{ width: '50%' }}>
           {type} 이미지 변경
         </Button>
-      </ButtonWrapper>
+      </Stack>
     </form>
   );
 };
@@ -119,14 +133,9 @@ const ImageForm = ({ type, oldImage, open, handleOpen }: Props) => {
 export default ImageForm;
 
 const InputWrapper = styled.div`
-  margin-top: 10px;
-  margin-bottom: 20px;
+  padding: 5px 18px 12px 18px;
 `;
 
 const ErrorText = styled.small`
   color: red;
-`;
-
-const ButtonWrapper = styled.div`
-  display: flex;
 `;

--- a/src/components/Profile/PasswordForm.tsx
+++ b/src/components/Profile/PasswordForm.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Button, TextField } from '@mui/material';
+import { Button, Stack, TextField } from '@mui/material';
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 
 import { putPassword } from '../../apis/userInfo';
@@ -89,8 +89,8 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
   };
 
   return (
-    <Form onSubmit={handleSubmit}>
-      <InputWrapper>
+    <form onSubmit={handleSubmit}>
+      <InputContainer>
         <TextField
           type='password'
           name='oldValue'
@@ -102,8 +102,6 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           fullWidth
           onChange={handleChange}
         />
-      </InputWrapper>
-      <InputWrapper>
         <TextField
           type='password'
           name='newValue'
@@ -116,8 +114,6 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           fullWidth
           onChange={handleChange}
         />
-      </InputWrapper>
-      <InputWrapper>
         <TextField
           type='password'
           name='newValueCheck'
@@ -129,15 +125,22 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           fullWidth
           onChange={handleChange}
         />
-      </InputWrapper>
-      <ButtonWrapper>
+      </InputContainer>
+      <Stack
+        direction='row'
+        spacing={0}
+        justifyContent='center'
+        sx={{ width: '100%' }}>
         <Button
           type='button'
           variant='outlined'
           color='warning'
+          size='large'
           disabled={isLoading}
-          fullWidth
-          onClick={handleOpen}>
+          onClick={handleOpen}
+          sx={{
+            width: '50%',
+          }}>
           취소
         </Button>
         <Button
@@ -145,26 +148,19 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           variant='contained'
           color='warning'
           disabled={isLoading}
-          fullWidth>
+          sx={{ width: '50%' }}>
           비밀번호 변경
         </Button>
-      </ButtonWrapper>
-    </Form>
+      </Stack>
+    </form>
   );
 };
 
 export default PasswordForm;
 
-const Form = styled.form`
-  width: 100%;
-  padding-top: 15px;
-`;
-
-const InputWrapper = styled.div`
-  width: 100%;
-  padding-bottom: 13px;
-`;
-
-const ButtonWrapper = styled.div`
+const InputContainer = styled.div`
   display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin: 8px 15px 18px 15px;
 `;

--- a/src/components/Profile/ProfileModal.tsx
+++ b/src/components/Profile/ProfileModal.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import { Modal, Typography } from '@mui/material';
-import { Box } from '@mui/system';
+import { createTheme, Dialog, ThemeProvider, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 
 import { ModalType } from '../../pages/Profile';
@@ -78,31 +77,55 @@ const ProfileModal = ({ type, user, open, handleOpen }: Props) => {
   };
 
   return (
-    <Modal open={open} onClose={handleOpen}>
-      <ContentWrapper>
-        <Typography variant='h6' component='h2'>
-          {modal[type].title}
-        </Typography>
-        {modal[type].form}
-      </ContentWrapper>
-    </Modal>
+    <ThemeProvider theme={theme}>
+      <Dialog open={open} onClose={handleOpen} disableScrollLock={true}>
+        <Container>
+          <TitleWrapper>
+            <Typography variant='h6' component='h2' sx={{ padding: '5px' }}>
+              {modal[type].title} 변경
+            </Typography>
+          </TitleWrapper>
+          <div>{modal[type].form}</div>
+        </Container>
+      </Dialog>
+    </ThemeProvider>
   );
 };
 
 export default ProfileModal;
 
-const ContentWrapper = styled(Box)`
+const Container = styled.div`
   display: flex;
   flex-direction: column;
-  position: absolute;
-  width: 50%;
-  min-width: 300px;
-  max-width: 500px;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 20px;
-  background-color: white;
-  border-radius: 10px;
-  box-shadow: 10px 5px 5px grey;
+  width: 300px;
+  overflow: hidden;
 `;
+
+const TitleWrapper = styled.div`
+  padding-top: 10px;
+  padding-left: 10px;
+`;
+
+const theme = createTheme({
+  typography: {
+    fontFamily: "'MaplestoryOTFLight', cursive",
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: '5%',
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: '0',
+          border: '0',
+          borderTop: '1px solid rgba(237, 108, 2, 0.5)',
+        },
+      },
+    },
+  },
+});

--- a/src/components/Profile/ProfileModal.tsx
+++ b/src/components/Profile/ProfileModal.tsx
@@ -114,7 +114,7 @@ const theme = createTheme({
     MuiPaper: {
       styleOverrides: {
         root: {
-          borderRadius: '5%',
+          borderRadius: '10px',
         },
       },
     },

--- a/src/components/Profile/TextForm.tsx
+++ b/src/components/Profile/TextForm.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Button, TextField } from '@mui/material';
+import { Button, Stack, TextField } from '@mui/material';
 import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
 
 import { putUserInfo } from '../../apis/userInfo';
@@ -92,26 +92,34 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
   };
 
   return (
-    <Form onSubmit={handleSubmit}>
-      <TextField
-        type='text'
-        value={value}
-        label={`새 ${type}`}
-        error={!!error}
-        color='warning'
-        helperText={error}
-        fullWidth
-        onChange={handleChange}
-        sx={{ marginBottom: '20px' }}
-      />
-      <ButtonWrapper>
+    <form onSubmit={handleSubmit}>
+      <TitleWrapper>
+        <TextField
+          type='text'
+          value={value}
+          label={`새 ${type}`}
+          error={!!error}
+          color='warning'
+          helperText={error}
+          fullWidth
+          onChange={handleChange}
+        />
+      </TitleWrapper>
+      <Stack
+        direction='row'
+        spacing={0}
+        justifyContent='center'
+        sx={{ width: '100%' }}>
         <Button
           type='button'
           variant='outlined'
           color='warning'
           disabled={isLoading}
-          fullWidth
-          onClick={handleOpen}>
+          size='large'
+          onClick={handleOpen}
+          sx={{
+            width: '50%',
+          }}>
           취소
         </Button>
         <Button
@@ -119,20 +127,16 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
           variant='contained'
           color='warning'
           disabled={isLoading}
-          fullWidth>
+          sx={{ width: '50%' }}>
           {type} 변경
         </Button>
-      </ButtonWrapper>
-    </Form>
+      </Stack>
+    </form>
   );
 };
 
 export default TextForm;
 
-const Form = styled.form`
-  margin: 15px 0;
-`;
-
-const ButtonWrapper = styled.div`
-  display: flex;
+const TitleWrapper = styled.div`
+  margin: 15px;
 `;

--- a/src/components/StoryEdit/ImageUpload.tsx
+++ b/src/components/StoryEdit/ImageUpload.tsx
@@ -108,6 +108,7 @@ const UploadContainer = styled(Box)`
   width: 100%;
   height: 300px;
   border: 1px dashed grey;
+  border-radius: 5px;
   cursor: pointer;
 `;
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -213,14 +213,14 @@ const ProfileImageWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  bottom: -70px;
+  bottom: -90px;
   left: 50%;
-  margin-left: -40px;
+  margin-left: -60px;
 `;
 
 const ProfileImage = styled(Avatar)`
-  width: 80px;
-  height: 80px;
+  width: 120px;
+  height: 120px;
   cursor: pointer;
 `;
 


### PR DESCRIPTION
# 이슈 번호가 있다면 적어주세요
#168 

## 작업 목록
- 모달 창을 Modal 대신 Dialog로 대체함(민우님이 구현하신 팔로우 모달 창 활용)
  - 다크모드 이슈 해결
- 프로필 이미지 크기 확대
- ImageUpload 컴포넌트 border-radius 추가

### 참고 사진이 있다면 첨부

<img src="https://user-images.githubusercontent.com/63575891/213630677-2847e8df-06bd-403f-92a2-5c05414fdfad.png" />
<img src="https://user-images.githubusercontent.com/63575891/213631891-3a08e40a-3614-45e1-92bc-b82f005b1679.png" />
<img src="https://user-images.githubusercontent.com/63575891/213631916-2556e246-5a10-4259-9a4b-3bd951ea4cf3.png" />
<img src="https://user-images.githubusercontent.com/63575891/213631937-3efc8a07-90e1-42a2-b000-3ed27969a7b9.png" />

## 예정
- 닉네임과 직업 유효성 검사 기준을 회원가입 기준과 통일하기
- 비밀번호 인풋의 공백 입력 방지

## 궁금한 점
