### PR TITLE
스토리 수정 페이지 진입 후 스토리 추가 버튼 눌렀을 때 리렌더링 처리

### DIFF
--- a/src/components/StoryEdit/StoryEditForm.tsx
+++ b/src/components/StoryEdit/StoryEditForm.tsx
@@ -3,34 +3,13 @@ import { Box } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 
 import { useStoryForm } from '../../hooks/useStory';
-import { StoryData } from '../../interfaces/story';
 import DatePicker from './DatePicker';
 import ImageUpload from './ImageUpload';
 import SubmitButton from './SubmitButton';
 import TextInput from './TextInput';
 
-interface Props {
-  story: StoryData;
-  isNew: boolean;
-}
-
-const setInitialValues = (story: StoryData) => {
-  if (story._id) {
-    const { storyTitle, year, month, day, content } = JSON.parse(story.title);
-
-    return {
-      title: storyTitle,
-      date: { year: Number(year), month: Number(month), date: Number(day) },
-      imageURL: story.image,
-      content,
-    };
-  }
-};
-
-const StoryEditForm = ({ story, isNew }: Props) => {
+const StoryEditForm = () => {
   const { state } = useLocation();
-
-  const initialValues = setInitialValues(isNew ? story : state);
 
   const {
     values,
@@ -43,12 +22,12 @@ const StoryEditForm = ({ story, isNew }: Props) => {
     handleImageChange,
     handleImageDelete,
     handleSubmit,
-  } = useStoryForm(initialValues);
+  } = useStoryForm(state);
 
   const image = values.imageURL || imageBase64;
 
   return (
-    <form onSubmit={(e) => handleSubmit(e, story.imagePublicId)}>
+    <form onSubmit={(e) => handleSubmit(e, state?.imagePublicId || '')}>
       <Section>
         <Box sx={{ width: '100%' }}>
           <DatePicker value={date} onChange={handleDateChange} />

--- a/src/hooks/useSignUpForm.ts
+++ b/src/hooks/useSignUpForm.ts
@@ -5,16 +5,11 @@ import { useNavigate } from 'react-router-dom';
 import { signin } from '../apis/auth';
 import { postSignUp } from '../apis/signup';
 import { CHANNEL_ID } from '../constants/apiParams';
+import { getDateInfo } from '../utils/helpers';
 import { signUpIsValid } from '../utils/signUpIsValid';
 import { signUpValidate } from '../utils/signUpValidate';
 import { postStory } from './../apis/story';
 import { ROUTES } from './../constants/routes';
-
-const getDateInfo = (date: Dayjs) => ({
-  year: date.get('year'),
-  month: date.get('month') + 1,
-  day: date.get('date'),
-});
 
 const error = {
   fullName: '',

--- a/src/interfaces/story.ts
+++ b/src/interfaces/story.ts
@@ -44,6 +44,7 @@ export interface StoryData {
   title: string;
   author: User;
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface StoryInfo {
@@ -53,6 +54,6 @@ export interface StoryInfo {
     month: number;
     day: number;
   };
-  imageURL: string;
+  imageURL?: string;
   content: string;
 }

--- a/src/interfaces/story.ts
+++ b/src/interfaces/story.ts
@@ -45,3 +45,14 @@ export interface StoryData {
   author: User;
   createdAt: string;
 }
+
+export interface StoryInfo {
+  title: string;
+  date: {
+    year: number;
+    month: number;
+    day: number;
+  };
+  imageURL: string;
+  content: string;
+}

--- a/src/pages/StoryEdit.tsx
+++ b/src/pages/StoryEdit.tsx
@@ -2,18 +2,14 @@ import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 
 import StoryEditForm from '../components/StoryEdit/StoryEditForm';
-import { useFetchStory } from '../hooks/useStory';
 
 const StoryEdit = () => {
-  const { story } = useFetchStory();
   const { storyId } = useParams();
-
-  const isNew = storyId === 'new';
 
   return (
     <Container>
-      <h1>스토리 {isNew ? '추가' : '수정'}</h1>
-      <StoryEditForm story={story} isNew={isNew} />
+      <h1>스토리 {storyId === 'new' ? '추가' : '수정'}</h1>
+      <StoryEditForm />
     </Container>
   );
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,13 @@
+import { Dayjs } from 'dayjs';
+
 export const changeColorTheme = (nextDisplayMode: 'dark' | 'light') => {
   nextDisplayMode === 'dark'
     ? document.documentElement.setAttribute('color-theme', 'dark')
     : document.documentElement.setAttribute('color-theme', 'light');
 };
+
+export const getDateInfo = (date: Dayjs) => ({
+  year: date.get('year'),
+  month: date.get('month') + 1,
+  day: date.get('date'),
+});


### PR DESCRIPTION
# 이슈 번호가 있다면 적어주세요
#203 

## 작업 목록
- 스토리 수정 페이지 진입 후 스토리 추가 버튼 눌렀을 때 빈 데이터 반영

### 참고 사진이 있다면 첨부

https://user-images.githubusercontent.com/63575891/213676479-6654a6c2-34e7-4ba3-8458-cea8827557ec.mov

## 예정
- 스토리 수정 후 페이지 이탈 방지

## 궁금한 점
