### PR TITLE
스토리 및 댓글 폼 레이아웃 수정

### DIFF
--- a/src/components/Story/CommentForm.tsx
+++ b/src/components/Story/CommentForm.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import { Button, TextField } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { IconButton, TextField } from '@mui/material';
 import { ChangeEvent, FormEvent } from 'react';
 
 import { TOKEN_KEY } from '../../constants/auth';
@@ -25,17 +26,18 @@ const CommentForm = ({
       <TextField
         fullWidth
         color='warning'
-        multiline
-        rows={4}
         placeholder={
           hasToken ? '댓글을 입력해 주세요.' : '로그인 후 이용해 주세요'
         }
         value={comment}
         onChange={handleChange}
         disabled={!hasToken}></TextField>
-      <Button color='warning' type='submit' disabled={!hasToken || isLoading}>
-        댓글 작성
-      </Button>
+      <IconButton
+        type='submit'
+        color='warning'
+        disabled={!hasToken || isLoading}>
+        <SendIcon />
+      </IconButton>
     </Form>
   );
 };
@@ -44,7 +46,6 @@ export default CommentForm;
 
 const Form = styled.form`
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 5px;
 `;

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -113,7 +113,7 @@ const StoryImage = styled.img`
 `;
 
 const StoryContentWrapper = styled.div`
-  min-width: 90%;
+  width: 100%;
   margin: 15px 0;
   line-height: 1.5rem;
   word-break: keep-all;

--- a/src/components/Story/StoryInfo.tsx
+++ b/src/components/Story/StoryInfo.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Avatar, Button, Paper, Typography } from '@mui/material';
+import { Avatar, Button, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useNavigate } from 'react-router-dom';
 
@@ -62,15 +62,11 @@ const StoryInfo = ({ story }: Props) => {
         </Box>
       </Box>
       <StoryContainer>
+        {content && <StoryContentWrapper>{content}</StoryContentWrapper>}
         {story.image && (
           <StoryImageWrapper>
             <StoryImage src={story.image} alt='story image' />
           </StoryImageWrapper>
-        )}
-        {content && (
-          <StoryContentWrapper variant='outlined'>
-            {content}
-          </StoryContentWrapper>
         )}
         <LikeButton
           user={user}
@@ -116,9 +112,8 @@ const StoryImage = styled.img`
   cursor: pointer;
 `;
 
-const StoryContentWrapper = styled(Paper)`
+const StoryContentWrapper = styled.div`
   min-width: 90%;
-  padding: 15px;
   margin: 15px 0;
   line-height: 1.5rem;
   word-break: keep-all;


### PR DESCRIPTION
# 이슈 번호가 있다면 적어주세요

## 작업 목록
- 스토리 내용과 사진 순서 변경
- 스토리 내용 border과 background-color 없앰
- 댓글 폼 모바일 UI로 변경 

### 참고 사진이 있다면 첨부
변경 전
<img width="30%" src="https://user-images.githubusercontent.com/63575891/213873419-f0c41502-ff50-41be-ae79-ca8eb9f619f9.png" />

변경 후
<img width="30%" src="https://user-images.githubusercontent.com/63575891/213873423-93c3849f-665a-48f2-9f73-06757fe71dd0.png" />

## 예정

## 궁금한 점
