### PR TITLE
닉네임/직업 변경 시 생년월일 데이터 유실되는 현상 해결

### DIFF
--- a/src/apis/userList.ts
+++ b/src/apis/userList.ts
@@ -1,7 +1,7 @@
 import { API_URLS } from './../constants/apiUrls';
 import http from './instance';
 
-export const userList = async () => {
+export const getUserList = async () => {
   try {
     const { data } = await http.get({
       url: API_URLS.USER.GET_USERS,

--- a/src/components/Profile/PasswordForm.tsx
+++ b/src/components/Profile/PasswordForm.tsx
@@ -36,7 +36,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setValues({ ...values, [name]: value });
+    setValues({ ...values, [name]: value.replace(/\s/g, '') });
   };
 
   const validate = () => {
@@ -50,7 +50,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
     else if (oldValue === newValue) {
       errors.newValue = '현재 비밀번호와 일치합니다.';
     } else if (!passwordRegex.test(newValue)) {
-      errors.newValue = '비밀번호는 6자리 이상, 15자리 이하로 입력해주세요';
+      errors.newValue = '6자리 이상, 15자리 이하로 입력해주세요';
     }
 
     if (isBlankString(newValueCheck))
@@ -97,6 +97,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           label='현재 비밀번호'
           size='small'
           color='warning'
+          value={values.oldValue}
           error={!!errors.oldValue}
           helperText={errors.oldValue}
           fullWidth
@@ -109,6 +110,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           placeholder='6-15자리'
           size='small'
           color='warning'
+          value={values.newValue}
           error={!!errors.newValue}
           helperText={errors.newValue}
           fullWidth
@@ -120,6 +122,7 @@ const PasswordForm = ({ open, handleOpen }: Props) => {
           label='새 비밀번호 확인'
           size='small'
           color='warning'
+          value={values.newValueCheck}
           error={!!errors.newValueCheck}
           helperText={errors.newValueCheck}
           fullWidth

--- a/src/components/Profile/ProfileModal.tsx
+++ b/src/components/Profile/ProfileModal.tsx
@@ -38,6 +38,7 @@ const ProfileModal = ({ type, user, open, handleOpen }: Props) => {
           fullName={user.fullName || ''}
           username={user.username || ''}
           open={open}
+          placeholder='영문, 한글, 숫자 2-8자리'
           handleOpen={handleOpen}></TextForm>
       ),
     },
@@ -49,6 +50,7 @@ const ProfileModal = ({ type, user, open, handleOpen }: Props) => {
           fullName={user.fullName || ''}
           username={user.username || ''}
           open={open}
+          placeholder='한글 2-6자리'
           handleOpen={handleOpen}></TextForm>
       ),
     },

--- a/src/components/Profile/TextForm.tsx
+++ b/src/components/Profile/TextForm.tsx
@@ -48,7 +48,7 @@ const TextForm = ({
   }, [open]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+    setValue(e.target.value.replace(/\s/g, ''));
   };
 
   const validate = (regex: RegExp) => {

--- a/src/components/Profile/TextForm.tsx
+++ b/src/components/Profile/TextForm.tsx
@@ -15,17 +15,17 @@ interface Props {
 }
 
 const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
-  const [initialValue, job, date] = useMemo(() => {
+  const [initialValue, job, year, month, day] = useMemo(() => {
+    const { job, year, month, day } = JSON.parse(username);
+
     let initialValue = '';
-    const job = username ? JSON.parse(username).job : '';
-    const date = username ? JSON.parse(username).date : {};
     if (type === '닉네임') {
       initialValue = fullName;
     } else if (type === '직업') {
       initialValue = job;
     }
 
-    return [initialValue, job, date];
+    return [initialValue, job, year, month, day];
   }, [username]);
 
   const [value, setValue] = useState(initialValue);
@@ -68,7 +68,9 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
           value,
           JSON.stringify({
             job,
-            date,
+            year,
+            month,
+            day,
           })
         );
       } else if (type === '직업') {
@@ -76,7 +78,9 @@ const TextForm = ({ type, fullName, username, open, handleOpen }: Props) => {
           fullName,
           JSON.stringify({
             job: value,
-            date,
+            year,
+            month,
+            day,
           })
         );
       }

--- a/src/hooks/useSignUpForm.ts
+++ b/src/hooks/useSignUpForm.ts
@@ -4,10 +4,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { signin } from '../apis/auth';
 import { postSignUp } from '../apis/signup';
-import { userList } from '../apis/userList';
+import { getUserList } from '../apis/userList';
 import { CHANNEL_ID } from '../constants/apiParams';
-import { getDateInfo } from '../utils/helpers';
 import { User } from '../interfaces/user';
+import { getDateInfo } from '../utils/helpers';
 import { signUpIsValid } from '../utils/signUpIsValid';
 import { signUpValidate } from '../utils/signUpValidate';
 import { postStory } from './../apis/story';
@@ -47,7 +47,7 @@ const useSignUpForm = () => {
   };
 
   const handleDuplicate = async () => {
-    const res = await userList();
+    const res = await getUserList();
     const nameList = res.map((user: User) => user.fullName);
     const fullNameRegex = /^[A-Za-z0-9가-힣]{2,8}$/;
     if (nameList.includes(values.fullName)) {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -40,14 +40,7 @@ const Profile = () => {
   if (isLoading) return <Loading />;
 
   const handleModalType = (e: MouseEvent) => {
-    if (
-      !(
-        e.target instanceof HTMLButtonElement ||
-        e.target instanceof HTMLDivElement
-      )
-    )
-      return;
-
+    if (!(e.target instanceof HTMLElement)) return;
     const { type } = e.target.dataset;
     if (!type) return;
 
@@ -100,8 +93,12 @@ const Profile = () => {
           <ProfileImage
             src={image}
             alt='profile image'
-            data-type='profileImage'
-            onClick={handleModalType}></ProfileImage>
+            imgProps={{
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              'data-type': 'profileImage',
+              onClick: handleModalType,
+            }}></ProfileImage>
           <Button
             color='warning'
             data-type='profileImage'


### PR DESCRIPTION
## 이슈 번호가 있다면 적어주세요

## 작업 목록
- 닉네임과 직업 변경 시 생년월일 데이터가 전달되지 않아 username에 포함되지 않는 버그 해결
- 커버 이미지처럼 프로필 이미지 클릭 시에도 이미지 변경 모달 창 열리게 함
- 닉네임/직업 변경 기준을 회원가입과 일치시킴
  - 닉네임 중복 검사
  - 닉네임/직업 유효성 검사
  - 비밀번호, 닉네임, 직업 공백 입력 불가

### 참고 사진이 있다면 첨부
<img width="50%" src="https://user-images.githubusercontent.com/63575891/213896513-b679ff9f-2e87-481b-a565-e86fc2399a61.gif" />

## 예정

## 궁금한 점
