### PR TITLE
404페이지 이미지 크기조정

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -40,5 +40,6 @@ const WarningContainer = styled.div`
 `;
 
 const Image = styled.img`
-  width: 20vw;
+  height: 400px;
+  width: 400px;
 `;


### PR DESCRIPTION
## 작업 목록
404페이지 진입시 사진을 불러오는 과정에서 레이아웃 쉬프트가 심하고
모바일 환경에서 이미지가 너무 작게 나와서
20vw -> 400px 정사각형으로 고정했습니다.