### PR TITLE
StoryBook 페이지 버그 해결 및 Image 로딩 시 Spinner 출력

### DIFF
--- a/src/components/StoryBook/StoriesByYear.tsx
+++ b/src/components/StoryBook/StoriesByYear.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { List } from '@mui/material';
+import { List, ListProps, styled as muiStyled } from '@mui/material';
 
 import { COLORS } from '../../constants/colors';
 import useDisplayModeContext from '../../contexts/DisplayModeContext';
@@ -36,6 +36,10 @@ const StoriesByYear = ({ year, stories }: StoriesWithYear) => {
 
 export default StoriesByYear;
 
+interface StyledListProps extends ListProps {
+  displayMode: string;
+}
+
 const Container = styled.div`
   margin-top: 0.3rem;
   margin-bottom: 1rem;
@@ -54,26 +58,27 @@ const Year = styled.div`
   color: white;
 `;
 
-const CardsContainer = styled(List)<{ displayMode: string }>`
-  flex: 1;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-end;
-  overflow-x: auto;
-  padding: 1rem;
-  background-color: ${({ displayMode }) =>
-    displayMode === 'dark' ? 'black' : 'white'};
-  transition: background-color 0.2s ease-out;
+const CardsContainer = muiStyled(List, {
+  shouldForwardProp: (prop) => prop !== 'displayMode',
+})<StyledListProps>(({ displayMode }) => ({
+  flex: 1,
+  display: 'flex',
+  flexWrap: 'nowrap',
+  alignItems: 'flex-end',
+  overflowX: 'auto',
+  padding: '1rem',
+  backgroundColor: displayMode === 'dark' ? 'black' : 'white',
+  transition: 'background-color 0.2s ease-out',
 
-  &::-webkit-scrollbar {
-    height: 0.15rem;
-  }
+  '&::-webkit-scrollbar': {
+    height: '0.15rem',
+  },
 
-  &::-webkit-scrollbar-thumb {
-    background-color: ${COLORS.SUB};
-    border-radius: 1rem;
-  }
-`;
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: COLORS.SUB,
+    borderRadius: '1rem',
+  },
+}));
 
 const CardContainer = styled.div`
   display: flex;

--- a/src/components/StoryBook/StoryCard.tsx
+++ b/src/components/StoryBook/StoryCard.tsx
@@ -11,6 +11,7 @@ import defaultImage from '../../assets/images/defaultImage.png';
 import { COLORS } from '../../constants/colors';
 import useLazyLoadImage from '../../hooks/useLazyLoadImage';
 import { Story } from '../../interfaces/story';
+import Loading from './Loading';
 
 interface Props {
   story: Story;
@@ -51,6 +52,7 @@ const StoryCard = ({ story, title, storyId, image, lazy = false }: Props) => {
         image={loaded ? (image ? image : defaultImage) : defaultImage}
         title={`${title} 사진`}
       />
+      {!loaded && <Loading />}
       <CardContent
         sx={{
           width: '100%',

--- a/src/components/StoryBook/StoryCard.tsx
+++ b/src/components/StoryBook/StoryCard.tsx
@@ -51,7 +51,10 @@ const StoryCard = ({ story, title, storyId, image, lazy = false }: Props) => {
         image={loaded ? (image ? image : defaultImage) : defaultImage}
         title={`${title} 사진`}
       />
-      <CardContent>
+      <CardContent
+        sx={{
+          width: '100%',
+        }}>
         <Typography
           sx={{
             textAlign: 'center',


### PR DESCRIPTION
#231 

## 작업 목록
- StoryBook 페이지에서 제목 길어지면 레이아웃 벗어나는 현상 해결
- image 로딩 시 Spinner 출력
- StoriesByYear에서 발생하는 에러 해결
  - emotion styled에서 mui styled로 변경
<img width="967" alt="image" src="https://user-images.githubusercontent.com/93233930/214891009-c3be9f78-ae39-44b6-a4ca-8b74ac5dbb1e.png">