### PR TITLE
팔로우 페이지 다크모드

### DIFF
--- a/src/components/Follow/FollowingButton.tsx
+++ b/src/components/Follow/FollowingButton.tsx
@@ -18,6 +18,7 @@ const FollowingButton = ({ isLoading, followId, userId, onClick }: Props) => {
           width: '100%',
           alignItems: 'center',
           position: 'relative',
+          marginRight: '10px',
         }}>
         <Button
           variant={isFollowing ? 'contained' : 'outlined'}

--- a/src/components/Follow/FollowingList.tsx
+++ b/src/components/Follow/FollowingList.tsx
@@ -36,8 +36,7 @@ const FollowingList = ({ userInfo }: Props) => {
       sx={{
         width: '100%',
         maxWidth: 360,
-        bgcolor:
-          displayMode === 'dark' ? COLORS.DARK_MODE_HEADER : 'background.paper',
+        bgcolor: displayMode === 'dark' ? COLORS.DARK_MODE_HEADER : 'white',
         borderRadius: '0.5rem',
       }}>
       <ListItem>

--- a/src/components/Follow/FollowingList.tsx
+++ b/src/components/Follow/FollowingList.tsx
@@ -10,6 +10,8 @@ import {
 import { styled } from '@mui/material/styles';
 import { useState } from 'react';
 
+import { COLORS } from '../../constants/colors';
+import useDisplayModeContext from '../../contexts/DisplayModeContext';
 import FollowModal from './FollowModal';
 
 interface Props {
@@ -26,6 +28,7 @@ interface Props {
 const FollowingList = ({ userInfo }: Props) => {
   const [open, setOpen] = useState(false);
   const handleClick = () => setOpen(!open);
+  const { displayMode } = useDisplayModeContext();
 
   return (
     <List
@@ -33,7 +36,8 @@ const FollowingList = ({ userInfo }: Props) => {
       sx={{
         width: '100%',
         maxWidth: 360,
-        bgcolor: 'background.paper',
+        bgcolor:
+          displayMode === 'dark' ? COLORS.DARK_MODE_HEADER : 'background.paper',
         borderRadius: '0.5rem',
       }}>
       <ListItem>

--- a/src/pages/follow.tsx
+++ b/src/pages/follow.tsx
@@ -33,6 +33,7 @@ const Follow = () => {
   const [value, setValue] = useState<FOLLOW>('FOLLOWING');
   const { followerList, loading, f4f, getUserInfo, handleClick } =
     useGetFollower();
+  const { displayMode } = useDisplayModeContext();
 
   const {
     followingList,
@@ -82,7 +83,9 @@ const Follow = () => {
               coverImage,
               username,
             }) => (
-              <Wrapper key={_id}>
+              <Wrapper
+                key={_id}
+                display={displayMode === 'dark' ? 'dark' : 'white'}>
                 <FollowingList
                   userInfo={{
                     image,
@@ -120,7 +123,9 @@ const Follow = () => {
               coverImage,
               username,
             }) => (
-              <Wrapper key={_id}>
+              <Wrapper
+                key={_id}
+                display={displayMode === 'dark' ? 'dark' : 'white'}>
                 <FollowingList
                   userInfo={{
                     image,
@@ -164,7 +169,7 @@ const LinkTab = (props: LinkTabProps) => {
   );
 };
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ display: string | null }>`
   display: flex;
   width: 100%;
   margin: 0 auto;
@@ -173,7 +178,8 @@ const Wrapper = styled.div`
   border-radius: 1rem;
   margin-bottom: 0.5rem;
   box-sizing: border-box;
-  background-color: white;
+  background-color: ${(props) =>
+    props.display === 'dark' ? '#121212' : 'white'};
 `;
 
 const tabsColor = createTheme({

--- a/src/pages/follow.tsx
+++ b/src/pages/follow.tsx
@@ -8,7 +8,7 @@ import {
   Tabs,
   ThemeProvider,
 } from '@mui/material';
-import { SyntheticEvent, useEffect, useState } from 'react';
+import { SyntheticEvent, useLayoutEffect, useState } from 'react';
 
 import FollowEmpty from '../components/Follow/FollowEmpty';
 import FollowerButton from '../components/Follow/FollowerButton';
@@ -43,10 +43,10 @@ const Follow = () => {
     handleClick: ingHandleClick,
   } = useGetFollow();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     getUserInfo();
     ingGetUserInfo();
-  }, []);
+  }, [value]);
 
   const handleChange = (e: SyntheticEvent, newValue: FOLLOW) => {
     setValue(newValue);
@@ -169,7 +169,7 @@ const LinkTab = (props: LinkTabProps) => {
   );
 };
 
-const Wrapper = styled.div<{ display: string | null }>`
+const Wrapper = styled.div<{ display: string }>`
   display: flex;
   width: 100%;
   margin: 0 auto;

--- a/src/pages/follow.tsx
+++ b/src/pages/follow.tsx
@@ -179,7 +179,7 @@ const Wrapper = styled.div<{ display: string }>`
   margin-bottom: 0.5rem;
   box-sizing: border-box;
   background-color: ${(props) =>
-    props.display === 'dark' ? '#121212' : 'white'};
+    props.display === 'dark' ? COLORS.DARK_MODE_HEADER : 'white'};
 `;
 
 const tabsColor = createTheme({

--- a/src/pages/follow.tsx
+++ b/src/pages/follow.tsx
@@ -44,8 +44,8 @@ const Follow = () => {
   } = useGetFollow();
 
   useLayoutEffect(() => {
-    getUserInfo();
-    ingGetUserInfo();
+    if (value === 'FOLLOWING') ingGetUserInfo();
+    else getUserInfo();
   }, [value]);
 
   const handleChange = (e: SyntheticEvent, newValue: FOLLOW) => {


### PR DESCRIPTION
## 작업 목록
- 팔로잉, 팔로우 버튼 마진 통일
- 다크모드 수정
- FOLLOWING / FOLLOWER 탭에 따라서 해당 페이지 렌더링

### 참고 사진이 있다면 첨부
전
<img src="https://user-images.githubusercontent.com/105067764/215083653-6f2fda3e-884a-4459-9f0c-a92c5ae5053a.png" width='40%' />
후
<img src="https://user-images.githubusercontent.com/105067764/215083661-d282feed-c020-4b0c-bf27-095fb6e0af9b.png" width='40%' />

## 예정
팔로잉과 팔로워의 변경이 있을때만 api를 호출하도록 최적화
